### PR TITLE
Respect NONE connection between pipes.

### DIFF
--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -329,6 +329,11 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
 	@Override
 	public boolean canConnect(EnumFacing side)
 	{
+		if(connectionTypes[side.ordinal()] == ConnectionType.NONE)
+		{
+			return false;
+		}
+
 		if(!redstoneSet)
 		{
 			if(redstoneReactive)
@@ -611,6 +616,10 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
 					sendDesc = true;
 
 					onModeChange(EnumFacing.getFront(hitSide.ordinal()));
+
+					refreshConnections();
+					notifyTileChange();
+
 					player.sendMessage(new TextComponentGroup().translation("tooltip.configurator.modeChange").string(" ").translation(connectionTypes[hitSide.ordinal()].translationKey()));
 
 					return EnumActionResult.SUCCESS;

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -482,6 +482,10 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
 	protected void onModeChange(EnumFacing side)
 	{
 		markDirtyAcceptor(side);
+		if (getPossibleTransmitterConnections() != currentTransmitterConnections)
+		{
+			markDirtyTransmitters();
+		}
 	}
 
 	protected void markDirtyTransmitters()
@@ -609,7 +613,12 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
 			}
 			else {
 				EnumFacing hitSide = sideHit(hit.subHit + 1);
-				
+
+				if(hitSide == null && connectionTypes[side.ordinal()] == ConnectionType.NONE)
+				{
+					hitSide = side;
+				}
+
 				if(hitSide != null)
 				{
 					connectionTypes[hitSide.ordinal()] = connectionTypes[hitSide.ordinal()].next();


### PR DESCRIPTION
Fixes #4781 

Quick and easy solution to make pipes not connect when one of both sides is configured with NONE.

Only drawback to this solution (and the reason I opened it as a PR) is that once set to NONE, they do not connect, and there's no way to reconfigure it back to normal/push/pull other than breaking the pipe and placing it again.

Confirmed that switching one pipe to none, the networks get separated and do not connect visual and "technical".