### PR TITLE
Item drop compatibility

### DIFF
--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -28,6 +28,7 @@ import mekanism.client.ClientTickHandler;
 import mekanism.common.Tier.BaseTier;
 import mekanism.common.base.IChunkLoadHandler;
 import mekanism.common.base.IModule;
+import mekanism.common.block.BlockBounding;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
 import mekanism.common.capabilities.Capabilities;
 import mekanism.common.chunkloading.ChunkManager;
@@ -772,6 +773,7 @@ public class Mekanism
 		
 		//Register to receive subscribed events
 		MinecraftForge.EVENT_BUS.register(this);
+		MinecraftForge.EVENT_BUS.register(BlockBounding.class);
 		
 		//Register this module's GUI handler in the simple packet protocol
 		PacketSimpleGui.handlers.add(0, proxy);

--- a/src/main/java/mekanism/common/block/BlockCardboardBox.java
+++ b/src/main/java/mekanism/common/block/BlockCardboardBox.java
@@ -9,8 +9,10 @@ import mekanism.common.MekanismBlocks;
 import mekanism.common.block.states.BlockStateCardboardBox;
 import mekanism.common.item.ItemBlockCardboardBox;
 import mekanism.common.tile.TileEntityCardboardBox;
+import mekanism.common.util.MekanismUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
+import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -24,6 +26,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.IBlockAccess;
@@ -75,7 +78,6 @@ public class BlockCardboardBox extends BlockContainer
 	{
 		if(!world.isRemote && entityplayer.isSneaking())
 		{
-			ItemStack itemStack = new ItemStack(MekanismBlocks.CardboardBox);
 			TileEntityCardboardBox tileEntity = (TileEntityCardboardBox)world.getTileEntity(pos);
 
 			if(tileEntity.storedData != null)
@@ -110,15 +112,8 @@ public class BlockCardboardBox extends BlockContainer
 				{
 					data.block.onBlockPlacedBy(world, pos, data.block.getStateFromMeta(data.meta), entityplayer, new ItemStack(data.block, 1, data.meta));
 				}
-				
-				float motion = 0.7F;
-				double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-				double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-				double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
 
-				EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, itemStack);
-
-				world.spawnEntity(entityItem);
+				spawnAsEntity(world, pos, new ItemStack(MekanismBlocks.CardboardBox));
 			}
 		}
 
@@ -137,22 +132,16 @@ public class BlockCardboardBox extends BlockContainer
 		return new TileEntityCardboardBox();
 	}
 
-	public ItemStack dismantleBlock(IBlockState state, World world, BlockPos pos, boolean returnBlock)
+	private ItemStack getDropItem(IBlockState state, IBlockAccess world, BlockPos pos)
 	{
-		ItemStack itemStack = getPickBlock(state, null, world, pos, null);
+		TileEntityCardboardBox tileEntity = (TileEntityCardboardBox)world.getTileEntity(pos);
 
-		world.setBlockToAir(pos);
+		Item item = Item.getItemFromBlock(state.getBlock());
+		ItemStack itemStack = new ItemStack(item, 1, state.getBlock().getMetaFromState(state));
 
-		if(!returnBlock)
+		if(tileEntity.storedData != null)
 		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, itemStack);
-
-			world.spawnEntity(entityItem);
+			((ItemBlockCardboardBox)item).setBlockData(itemStack, tileEntity.storedData);
 		}
 
 		return itemStack;
@@ -161,49 +150,57 @@ public class BlockCardboardBox extends BlockContainer
 	@Override
     public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
 	{
-		TileEntityCardboardBox tileEntity = (TileEntityCardboardBox)world.getTileEntity(pos);
-
-		ItemStack itemStack = new ItemStack(state.getBlock(), 1, state.getBlock().getMetaFromState(state));
-
-		if(itemStack.getItemDamage() == 1)
-		{
-			if(tileEntity.storedData != null)
-			{
-				((ItemBlockCardboardBox)itemStack.getItem()).setBlockData(itemStack, tileEntity.storedData);
-			}
-		}
-
-		return itemStack;
+		return getDropItem(state, world, pos);
 	}
 
 	@Override
-	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player, boolean willHarvest)
+	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
 	{
-		if(!player.capabilities.isCreativeMode && !world.isRemote && willHarvest)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, getPickBlock(state, null, world, pos, player));
-
-			world.spawnEntity(entityItem);
-		}
-
-		return world.setBlockToAir(pos);
+		drops.add(getDropItem(state, world, pos));
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Keep tile entity in world until after
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)}.
+	 * Used together with {@link Block#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)
+	 */
 	@Override
-	public int quantityDropped(Random random)
+	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player,
+	                               boolean willHarvest)
 	{
-		return 0;
+		return willHarvest || super.removedByPlayer(state, world, pos, player, willHarvest);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 * Used together with {@link Block#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)
+	 */
 	@Override
-	public Item getItemDropped(IBlockState state, Random random, int fortune)
+	public void harvestBlock(World world, EntityPlayer player, BlockPos pos, IBlockState state, TileEntity te, ItemStack stack)
 	{
-		return Items.AIR;
+		MekanismUtils.harvestBlockPatched(this, getDropItem(state, world, pos), world, player, pos, te);
+		world.setBlockToAir(pos);
+	}
+
+	/**
+	 * Returns that this "cannot" be silk touched.
+	 * This is so that {@link Block#getSilkTouchDrop(IBlockState)} is not called, because only
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)} supports tile entities.
+	 * Our blocks keep their inventory and other behave like they are being silk touched by default anyway.
+	 *
+	 * @return false
+	 */
+	@Override
+	protected boolean canSilkHarvest()
+	{
+		return false;
 	}
 
 	public static class BlockData

--- a/src/main/java/mekanism/common/block/BlockEnergyCube.java
+++ b/src/main/java/mekanism/common/block/BlockEnergyCube.java
@@ -23,6 +23,7 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.SecurityUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
+import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -152,18 +153,6 @@ public class BlockEnergyCube extends BlockContainer
 	}
 
 	@Override
-	public int quantityDropped(Random random)
-	{
-		return 0;
-	}
-
-	@Override
-	public Item getItemDropped(IBlockState state, Random random, int fortune)
-	{
-		return null;
-	}
-
-	@Override
 	public void getSubBlocks(CreativeTabs creativetabs, NonNullList<ItemStack> list)
 	{
 		for(EnergyCubeTier tier : EnergyCubeTier.values())
@@ -209,8 +198,7 @@ public class BlockEnergyCube extends BlockContainer
 
 						if(entityplayer.isSneaking())
 						{
-							dismantleBlock(state, world, pos, false);
-
+							MekanismUtils.dismantleBlock(this, state, world, pos);
 							return true;
 						}
 
@@ -250,23 +238,6 @@ public class BlockEnergyCube extends BlockContainer
 	}
 
 	@Override
-	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player, boolean willHarvest)
-	{
-		if(!player.capabilities.isCreativeMode && !world.isRemote && willHarvest)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, getPickBlock(state, null, world, pos, player));
-			world.spawnEntity(entityItem);
-		}
-
-		return world.setBlockToAir(pos);
-	}
-
-	@Override
 	public TileEntity createNewTileEntity(World world, int meta)
 	{
 		return new TileEntityEnergyCube();
@@ -284,9 +255,7 @@ public class BlockEnergyCube extends BlockContainer
 		return EnumBlockRenderType.MODEL;
 	}
 
-	@Override
-    public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
-	{
+	private ItemStack getDropItem(IBlockAccess world, BlockPos pos) {
 		TileEntityEnergyCube tileEntity = (TileEntityEnergyCube)world.getTileEntity(pos);
 		ItemStack itemStack = new ItemStack(MekanismBlocks.EnergyCube);
 		
@@ -326,25 +295,61 @@ public class BlockEnergyCube extends BlockContainer
 		return itemStack;
 	}
 
-	public ItemStack dismantleBlock(IBlockState state, World world, BlockPos pos, boolean returnBlock)
+	@Override
+	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
 	{
-		ItemStack itemStack = getPickBlock(state, null, world, pos, null);
+		return getDropItem(world, pos);
+	}
 
+	@Override
+	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
+	{
+		drops.add(getDropItem(world, pos));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * Keep tile entity in world until after
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)}.
+	 * Used together with {@link Block#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)
+	 */
+	@Override
+	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player,
+	                               boolean willHarvest)
+	{
+		return willHarvest || super.removedByPlayer(state, world, pos, player, willHarvest);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * Used together with {@link Block#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)
+	 */
+	@Override
+	public void harvestBlock(World world, EntityPlayer player, BlockPos pos,
+	                         IBlockState state, TileEntity te, ItemStack stack)
+	{
+		MekanismUtils.harvestBlockPatched(this, getDropItem(world, pos), world, player, pos, te);
 		world.setBlockToAir(pos);
+	}
 
-		if(!returnBlock)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, itemStack);
-
-			world.spawnEntity(entityItem);
-		}
-
-		return itemStack;
+	/**
+	 * Returns that this "cannot" be silk touched.
+	 * This is so that {@link Block#getSilkTouchDrop(IBlockState)} is not called, because only
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)} supports tile entities.
+	 * Our blocks keep their inventory and other behave like they are being silk touched by default anyway.
+	 *
+	 * @return false
+	 */
+	@Override
+	protected boolean canSilkHarvest()
+	{
+		return false;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/block/BlockGasTank.java
+++ b/src/main/java/mekanism/common/block/BlockGasTank.java
@@ -21,6 +21,7 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.SecurityUtils;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
+import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
@@ -34,6 +35,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.MathHelper;
@@ -163,8 +165,7 @@ public class BlockGasTank extends BlockContainer
 
 						if(entityplayer.isSneaking())
 						{
-							dismantleBlock(state, world, pos, false);
-
+							MekanismUtils.dismantleBlock(this, state, world, pos);
 							return true;
 						}
 
@@ -205,57 +206,6 @@ public class BlockGasTank extends BlockContainer
 	}
 
 	@Override
-	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player, boolean willHarvest)
-	{
-		if(!player.capabilities.isCreativeMode && !world.isRemote && willHarvest)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, getPickBlock(state, null, world, pos, player));
-
-			world.spawnEntity(entityItem);
-		}
-
-		return world.setBlockToAir(pos);
-	}
-
-	public ItemStack dismantleBlock(IBlockState state, World world, BlockPos pos, boolean returnBlock)
-	{
-		ItemStack itemStack = getPickBlock(state, null, world, pos, null);
-
-		world.setBlockToAir(pos);
-
-		if(!returnBlock)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, itemStack);
-
-			world.spawnEntity(entityItem);
-		}
-
-		return itemStack;
-	}
-
-	@Override
-	public int quantityDropped(Random random)
-	{
-		return 0;
-	}
-
-	@Override
-	public Item getItemDropped(IBlockState state, Random random, int fortune)
-	{
-		return null;
-	}
-
-	@Override
 	public boolean isOpaqueCube(IBlockState state)
 	{
 		return false;
@@ -279,9 +229,7 @@ public class BlockGasTank extends BlockContainer
 		return new TileEntityGasTank();
 	}
 
-	@Override
-	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
-	{
+	private ItemStack getDropItem(IBlockAccess world, BlockPos pos) {
 		TileEntityGasTank tileEntity = (TileEntityGasTank)world.getTileEntity(pos);
 		ItemStack itemStack = new ItemStack(MekanismBlocks.GasTank);
 		
@@ -319,6 +267,63 @@ public class BlockGasTank extends BlockContainer
 		inventory.setInventory(tileEntity.getInventory(), itemStack);
 
 		return itemStack;
+	}
+
+	@Override
+	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
+	{
+		return getDropItem(world, pos);
+	}
+
+	@Override
+	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
+	{
+		drops.add(getDropItem(world, pos));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * Keep tile entity in world until after
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)}.
+	 * Used together with {@link Block#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)
+	 */
+	@Override
+	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player,
+	                               boolean willHarvest)
+	{
+		return willHarvest || super.removedByPlayer(state, world, pos, player, willHarvest);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * Used together with {@link Block#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)
+	 */
+	@Override
+	public void harvestBlock(World world, EntityPlayer player, BlockPos pos,
+	                         IBlockState state, TileEntity te, ItemStack stack)
+	{
+		MekanismUtils.harvestBlockPatched(this, getDropItem(world, pos), world, player, pos, te);
+		world.setBlockToAir(pos);
+	}
+
+	/**
+	 * Returns that this "cannot" be silk touched.
+	 * This is so that {@link Block#getSilkTouchDrop(IBlockState)} is not called, because only
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)} supports tile entities.
+	 * Our blocks keep their inventory and other behave like they are being silk touched by default anyway.
+	 *
+	 * @return false
+	 */
+	@Override
+	protected boolean canSilkHarvest()
+	{
+		return false;
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/block/BlockGlowPanel.java
+++ b/src/main/java/mekanism/common/block/BlockGlowPanel.java
@@ -13,6 +13,7 @@ import mekanism.common.tile.TileEntityGlowPanel;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.MultipartUtils;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
@@ -24,6 +25,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
@@ -103,36 +105,8 @@ public class BlockGlowPanel extends Block implements ITileEntityProvider
 		
 		if(tileEntity != null && !world.isRemote && !canStay(world, pos))
 		{
-			float motion = 0.7F;
-			double motionX = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			ItemStack stack = new ItemStack(MekanismBlocks.GlowPanel, 1, tileEntity.colour.getMetaValue());
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, stack);
-
-			world.spawnEntity(entityItem);
+			dropBlockAsItem(world, pos, world.getBlockState(pos), 0);
 			world.setBlockToAir(pos);
-		}
-	}
-	
-	@Override
-	public void onNeighborChange(IBlockAccess world, BlockPos pos, BlockPos neighbor)
-	{
-		TileEntityGlowPanel tileEntity = getTileEntityGlowPanel(world, pos);
-		
-		if(tileEntity != null && !tileEntity.getWorld().isRemote && !canStay(world, pos))
-		{
-			float motion = 0.7F;
-			double motionX = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			ItemStack stack = new ItemStack(MekanismBlocks.GlowPanel, 1, tileEntity.colour.getMetaValue());
-			EntityItem entityItem = new EntityItem(tileEntity.getWorld(), pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, stack);
-
-			tileEntity.getWorld().spawnEntity(entityItem);
-			tileEntity.getWorld().setBlockToAir(pos);
 		}
 	}
 	
@@ -183,36 +157,67 @@ public class BlockGlowPanel extends Block implements ITileEntityProvider
     {
 		return 15;
     }
-	
-	@Override
-	public int quantityDropped(Random random)
-    {
-		return 0;
-    }
-	
-	@Override
-    public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
-	{
+
+	private ItemStack getDropItem(IBlockAccess world, BlockPos pos) {
 		TileEntityGlowPanel tileEntity = (TileEntityGlowPanel)world.getTileEntity(pos);
 		return new ItemStack(MekanismBlocks.GlowPanel, 1, tileEntity.colour.getMetaValue());
 	}
 
 	@Override
-	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player, boolean willHarvest)
+	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
 	{
-		if(!player.capabilities.isCreativeMode && !world.isRemote && willHarvest)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
+		return getDropItem(world, pos);
+	}
 
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, getPickBlock(state, null, world, pos, player));
+	@Override
+	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
+	{
+		drops.add(getDropItem(world, pos));
+	}
 
-			world.spawnEntity(entityItem);
-		}
+	/**
+	 * {@inheritDoc}
+	 * Keep tile entity in world until after
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)}.
+	 * Used together with {@link Block#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)
+	 */
+	@Override
+	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player,
+	                               boolean willHarvest)
+	{
+		return willHarvest || super.removedByPlayer(state, world, pos, player, willHarvest);
+	}
 
-		return super.removedByPlayer(state, world, pos, player, willHarvest);
+	/**
+	 * {@inheritDoc}
+	 * Used together with {@link Block#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)
+	 */
+	@Override
+	public void harvestBlock(World world, EntityPlayer player, BlockPos pos,
+	                         IBlockState state, TileEntity te, ItemStack stack)
+	{
+		super.harvestBlock(world, player, pos, state, te, stack);
+		world.setBlockToAir(pos);
+	}
+
+	/**
+	 * Returns that this "cannot" be silk touched.
+	 * This is so that {@link Block#getSilkTouchDrop(IBlockState)} is not called, because only
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)} supports tile entities.
+	 * Our blocks keep their inventory and other behave like they are being silk touched by default anyway.
+	 *
+	 * @return false
+	 */
+	@Override
+	protected boolean canSilkHarvest()
+	{
+		return false;
 	}
 	
 	@Override

--- a/src/main/java/mekanism/common/block/BlockTransmitter.java
+++ b/src/main/java/mekanism/common/block/BlockTransmitter.java
@@ -30,6 +30,7 @@ import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.MultipartUtils;
 import mekanism.common.util.MultipartUtils.AdvancedRayTraceResult;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockFlowerPot;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.BlockStateContainer;
@@ -222,7 +223,7 @@ public class BlockTransmitter extends Block implements ITileEntityProvider
 			{
 				if(!world.isRemote)
 				{
-					dismantleBlock(state, world, pos, false);
+					MekanismUtils.dismantleBlock(this, state, world, pos);
 				}
 
 				return true;
@@ -231,16 +232,12 @@ public class BlockTransmitter extends Block implements ITileEntityProvider
 
 		return false;
 	}
-	
-	@Override
-    public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
-	{
-		ItemStack itemStack = ItemStack.EMPTY;
+
+	private ItemStack getDropItem(IBlockAccess world, BlockPos pos) {
 		TileEntitySidedPipe tileEntity = getTileEntitySidedPipe(world, pos);
 		if(tileEntity != null)
 		{
-			itemStack = new ItemStack(MekanismBlocks.Transmitter, 1, tileEntity.getTransmitterType().ordinal());
-			
+			ItemStack itemStack = new ItemStack(MekanismBlocks.Transmitter, 1, tileEntity.getTransmitterType().ordinal());
 			if(!itemStack.hasTagCompound())
 			{
 				itemStack.setTagCompound(new NBTTagCompound());
@@ -248,30 +245,69 @@ public class BlockTransmitter extends Block implements ITileEntityProvider
 			
 			ITierItem tierItem = (ITierItem)itemStack.getItem();
 			tierItem.setBaseTier(itemStack, tileEntity.getBaseTier());
-		}
 
-		return itemStack;
+			return itemStack;
+		}
+		else {
+			return ItemStack.EMPTY;
+		}
 	}
 
-	public ItemStack dismantleBlock(IBlockState state, World world, BlockPos pos, boolean returnBlock)
+	@Override
+	public ItemStack getPickBlock(IBlockState state, RayTraceResult target, World world, BlockPos pos, EntityPlayer player)
 	{
-		ItemStack itemStack = getPickBlock(state, null, world, pos, null);
+		return getDropItem(world, pos);
+	}
 
+	@Override
+	public void getDrops(NonNullList<ItemStack> drops, IBlockAccess world, BlockPos pos, IBlockState state, int fortune)
+	{
+		drops.add(getDropItem(world, pos));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * Keep tile entity in world until after
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)}.
+	 * Used together with {@link Block#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)
+	 */
+	@Override
+	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player,
+	                               boolean willHarvest)
+	{
+		return willHarvest || super.removedByPlayer(state, world, pos, player, willHarvest);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * Used together with {@link Block#removedByPlayer(IBlockState, World, BlockPos, EntityPlayer, boolean)}.
+	 *
+	 * @author Forge
+	 * @see BlockFlowerPot#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)
+	 */
+	@Override
+	public void harvestBlock(World world, EntityPlayer player, BlockPos pos,
+	                         IBlockState state, TileEntity te, ItemStack stack)
+	{
+		super.harvestBlock(world, player, pos, state, te, stack);
 		world.setBlockToAir(pos);
+	}
 
-		if(!returnBlock)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, itemStack);
-
-			world.spawnEntity(entityItem);
-		}
-
-		return itemStack;
+	/**
+	 * Returns that this "cannot" be silk touched.
+	 * This is so that {@link Block#getSilkTouchDrop(IBlockState)} is not called, because only
+	 * {@link Block#getDrops(NonNullList, IBlockAccess, BlockPos, IBlockState, int)} supports tile entities.
+	 * Our blocks keep their inventory and other behave like they are being silk touched by default anyway.
+	 *
+	 * @return false
+	 */
+	@Override
+	protected boolean canSilkHarvest()
+	{
+		return false;
 	}
 	
 	@Override
@@ -369,30 +405,6 @@ public class BlockTransmitter extends Block implements ITileEntityProvider
     {
         return false;
     }
-    
-    @Override
-	public int quantityDropped(Random random)
-	{
-		return 0;
-	}
-    
-    @Override
-	public boolean removedByPlayer(IBlockState state, World world, BlockPos pos, EntityPlayer player, boolean willHarvest)
-	{
-		if(!player.capabilities.isCreativeMode && !world.isRemote && willHarvest)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, getPickBlock(state, null, world, pos, player));
-
-			world.spawnEntity(entityItem);
-		}
-
-		return super.removedByPlayer(state, world, pos, player, willHarvest);
-	}
 
     private static AxisAlignedBB getDefaultForTile(TileEntitySidedPipe tile)
     {

--- a/src/main/java/mekanism/common/integration/multipart/MultipartGlowPanel.java
+++ b/src/main/java/mekanism/common/integration/multipart/MultipartGlowPanel.java
@@ -25,8 +25,6 @@ import net.minecraft.world.World;
 
 public class MultipartGlowPanel implements IMultipart
 {
-	private static Random rand = new Random();
-	
 	@Override
 	public IPartSlot getSlotForPlacement(World world, BlockPos pos, IBlockState state, EnumFacing facing, float hitX, float hitY,float hitZ, EntityLivingBase placer) 
 	{
@@ -60,17 +58,10 @@ public class MultipartGlowPanel implements IMultipart
 		TileEntity tile = part.getTile().getTileEntity();
 		if(tile instanceof TileEntityGlowPanel && !BlockGlowPanel.canStay(part.getPartWorld(), part.getPartPos()))
 		{
-			float motion = 0.7F;
-			double motionX = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
 			BlockPos pos = part.getPartPos();
 			TileEntityGlowPanel glowPanel = (TileEntityGlowPanel)tile;
 			ItemStack stack = new ItemStack(MekanismBlocks.GlowPanel, 1, glowPanel.colour.getMetaValue());
-			EntityItem entityItem = new EntityItem(glowPanel.getWorld(), pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, stack);
-
-			part.getActualWorld().spawnEntity(entityItem);
+			Block.spawnAsEntity(part.getActualWorld(), pos, stack);
 			part.remove();
 		}
 	}

--- a/src/main/java/mekanism/common/item/ItemConfigurator.java
+++ b/src/main/java/mekanism/common/item/ItemConfigurator.java
@@ -169,22 +169,7 @@ public class ItemConfigurator extends ItemEnergized implements IMekWrench, ITool
 									break;
 								}
 
-								float xRandom = random.nextFloat() * 0.8F + 0.1F;
-								float yRandom = random.nextFloat() * 0.8F + 0.1F;
-								float zRandom = random.nextFloat() * 0.8F + 0.1F;
-
-								EntityItem item = new EntityItem(world, pos.getX() + xRandom, pos.getY() + yRandom, pos.getZ() + zRandom, slotStack.copy());
-
-								if(slotStack.hasTagCompound())
-								{
-									item.getItem().setTagCompound((NBTTagCompound)slotStack.getTagCompound().copy());
-								}
-
-								float k = 0.05F;
-								item.motionX = random.nextGaussian() * k;
-								item.motionY = random.nextGaussian() * k + 0.2F;
-								item.motionZ = random.nextGaussian() * k;
-								world.spawnEntity(item);
+								Block.spawnAsEntity(world, pos, slotStack.copy());
 
 								inv.setInventorySlotContents(i, ItemStack.EMPTY);
 								setEnergy(stack, getEnergy(stack) - ENERGY_PER_ITEM_DUMP);

--- a/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
+++ b/src/main/java/mekanism/common/tile/TileEntityLaserTractorBeam.java
@@ -19,6 +19,7 @@ import mekanism.common.tile.component.TileComponentSecurity;
 import mekanism.common.tile.prefab.TileEntityContainerBlock;
 import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.StackUtils;
+import net.minecraft.block.Block;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
@@ -181,19 +182,9 @@ public class TileEntityLaserTractorBeam extends TileEntityContainerBlock impleme
 					if(drop.getCount() <= 0) continue outer;
 				}
 			}
-			
-			dropItem(drop);
-		}
-	}
 
-	public void dropItem(ItemStack stack)
-	{
-		EntityItem item = new EntityItem(world, getPos().getX() + 0.5, getPos().getY() + 1, getPos().getZ() + 0.5, stack);
-		item.motionX = world.rand.nextGaussian() * 0.05;
-		item.motionY = world.rand.nextGaussian() * 0.05 + 0.2;
-		item.motionZ = world.rand.nextGaussian() * 0.05;
-		item.setPickupDelay(10);
-		world.spawnEntity(item);
+			Block.spawnAsEntity(world, pos, drop);
+		}
 	}
 
 	@Override

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -57,6 +57,7 @@ import mekanism.common.tile.component.SideConfig;
 import mekanism.common.util.UnitDisplayUtils.ElectricUnit;
 import mekanism.common.util.UnitDisplayUtils.TemperatureUnit;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockLiquid;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.gui.FontRenderer;
@@ -69,6 +70,7 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.stats.StatList;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumFacing.Axis;
@@ -81,6 +83,7 @@ import net.minecraft.util.text.TextComponentString;
 import net.minecraft.world.ChunkCache;
 import net.minecraft.world.EnumSkyBlock;
 import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.IWorldNameable;
 import net.minecraft.world.World;
 import net.minecraftforge.common.UsernameCache;
 import net.minecraft.world.chunk.Chunk;
@@ -1591,5 +1594,33 @@ public final class MekanismUtils
 	public static TileEntity getTileEntitySafe(IBlockAccess worldIn, BlockPos pos)
 	{
 		return worldIn instanceof ChunkCache ? ((ChunkCache)worldIn).getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : worldIn.getTileEntity(pos);
+	}
+
+	/**
+	 * Dismantles a block, dropping it and removing it from the world.
+	 */
+	public static void dismantleBlock(Block block, IBlockState state, World world, BlockPos pos) {
+		block.dropBlockAsItem(world, pos, state, 0);
+		world.setBlockToAir(pos);
+	}
+
+	/**
+	 * Vanilla {@link BlockContainer#harvestBlock(World, EntityPlayer, BlockPos, IBlockState, TileEntity, ItemStack)}
+	 * except that is supports a custom {@link ItemStack} from <code>getDropItem()</code>-like things.
+	 *
+	 * Use only for {@link BlockContainer}s.
+	 */
+	@SuppressWarnings("ConstantConditions")
+	public static void harvestBlockPatched(Block block, ItemStack itemstack, World world, EntityPlayer player,
+	                                       BlockPos pos, TileEntity te)
+	{
+		player.addStat(StatList.getBlockStats(block));
+		player.addExhaustion(0.005F);
+		if (world.isRemote) {
+			return;
+		}
+
+		itemstack.setStackDisplayName(((IWorldNameable)te).getName());
+		Block.spawnAsEntity(world, pos, itemstack);
 	}
 }

--- a/src/main/java/mekanism/common/util/TransporterUtils.java
+++ b/src/main/java/mekanism/common/util/TransporterUtils.java
@@ -12,10 +12,12 @@ import mekanism.common.content.transporter.TransporterManager;
 import mekanism.common.content.transporter.TransporterStack;
 import mekanism.common.tile.TileEntityLogisticalSorter;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.block.Block;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.ISidedInventory;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
 
 public final class TransporterUtils
 {
@@ -105,13 +107,8 @@ public final class TransporterUtils
 
 		TransporterManager.remove(stack);
 
-		EntityItem entityItem = new EntityItem(tileEntity.world(), tileEntity.coord().x + pos[0], tileEntity.coord().y + pos[1], tileEntity.coord().z + pos[2], stack.itemStack);
-
-		entityItem.motionX = 0;
-		entityItem.motionY = 0;
-		entityItem.motionZ = 0;
-
-		tileEntity.world().spawnEntity(entityItem);
+		BlockPos blockPos = new BlockPos(tileEntity.coord().x + pos[0], tileEntity.coord().y + pos[1], tileEntity.coord().z + pos[2]);
+		Block.spawnAsEntity(tileEntity.world(), blockPos, stack.itemStack);
 	}
 
 	public static float[] getStackPosition(ILogisticalTransporter tileEntity, TransporterStack stack, float partial)

--- a/src/main/java/mekanism/generators/common/block/BlockReactor.java
+++ b/src/main/java/mekanism/generators/common/block/BlockReactor.java
@@ -140,7 +140,7 @@ public abstract class BlockReactor extends Block implements ITileEntityProvider
 			{
 				if(entityplayer.isSneaking())
 				{
-					dismantleBlock(world, pos, false);
+					MekanismUtils.dismantleBlock(this, state, world, pos);
 					return true;
 				}
 
@@ -290,28 +290,6 @@ public abstract class BlockReactor extends Block implements ITileEntityProvider
 			default:
 				return false;
 		}
-	}
-
-	public ItemStack dismantleBlock(World world, BlockPos pos, boolean returnBlock)
-	{
-		IBlockState state = world.getBlockState(pos);
-		ItemStack itemStack = new ItemStack(this, 1, state.getBlock().getMetaFromState(state));
-
-		world.setBlockToAir(pos);
-
-		if(!returnBlock)
-		{
-			float motion = 0.7F;
-			double motionX = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionY = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-			double motionZ = (world.rand.nextFloat() * motion) + (1.0F - motion) * 0.5D;
-
-			EntityItem entityItem = new EntityItem(world, pos.getX() + motionX, pos.getY() + motionY, pos.getZ() + motionZ, itemStack);
-
-			world.spawnEntity(entityItem);
-		}
-
-		return itemStack;
 	}
 
 	public PropertyEnum<ReactorBlockType> getTypeProperty()


### PR DESCRIPTION
Fix machines disappearing after mining/wrenching.
Fix RFTools builder losing machines.
Simplify and use methods in Block instead of calculating drops.
Make drops behave the same as mined blocks.