### PR TITLE
Fix TransporterStack home locations & DM inventory interaction

### DIFF
--- a/src/main/java/mekanism/common/base/IAdvancedBoundingBlock.java
+++ b/src/main/java/mekanism/common/base/IAdvancedBoundingBlock.java
@@ -11,7 +11,6 @@ import mekanism.common.integration.MekanismHooks;
 import mekanism.common.integration.computer.IComputerIntegration;
 import mekanism.common.security.ISecurityTile;
 import net.minecraft.inventory.ISidedInventory;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
@@ -26,12 +25,6 @@ import net.minecraftforge.fml.common.Optional.InterfaceList;
 public interface IAdvancedBoundingBlock extends ICapabilityProvider, IBoundingBlock, ISidedInventory, IEnergySink,
       IStrictEnergyAcceptor, IStrictEnergyStorage, IEnergyReceiver, IEnergyProvider, IComputerIntegration,
       ISpecialConfigData, ISecurityTile, IOffsetCapability {
-
-    int[] getBoundSlots(BlockPos location, EnumFacing side);
-
-    boolean canBoundInsert(BlockPos location, int i, ItemStack itemstack);
-
-    boolean canBoundExtract(BlockPos location, int i, ItemStack itemstack, EnumFacing side);
 
     boolean canBoundReceiveEnergy(BlockPos location, EnumFacing side);
 

--- a/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
+++ b/src/main/java/mekanism/common/content/transporter/TransporterPathfinder.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nonnull;
+import org.apache.commons.lang3.tuple.Pair;
 import mekanism.api.Coord4D;
 import mekanism.common.base.ILogisticalTransporter;
 import mekanism.common.capabilities.Capabilities;
@@ -24,7 +25,6 @@ import mekanism.common.util.InventoryUtils;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
-import org.apache.commons.lang3.tuple.Pair;
 
 public final class TransporterPathfinder {
 
@@ -453,7 +453,9 @@ public final class TransporterPathfinder {
                     neighbors[direction.ordinal()] = neighbor;
                     TileEntity neighborEntity = neighbor.getTileEntity(worldObj);
                     neighborEntities[direction.ordinal()] = neighborEntity;
-                    if (currentNodeTransporter == null || currentNodeTransporter.canEmitTo(neighborEntity, direction)) {
+                    if ((currentNodeTransporter == null || currentNodeTransporter.canEmitTo(neighborEntity, direction)) ||
+                        (neighbor.equals(finalNode) && destChecker
+                          .isValid(transportStack, direction, neighborEntities[direction.ordinal()]))) {
                         directionsToCheck.add(direction);
                     }
                 }

--- a/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityAdvancedBoundingBlock.java
@@ -172,7 +172,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
             return false;
         }
 
-        return inv.canBoundInsert(getPos(), i, itemstack);
+        return inv.isItemValidForSlot(i, itemstack);
     }
 
     @Override
@@ -202,12 +202,17 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
             return InventoryUtils.EMPTY;
         }
 
-        return inv.getBoundSlots(getPos(), side);
+        return inv.getSlotsForFace(side);
     }
 
     @Override
     public boolean canInsertItem(int i, @Nonnull ItemStack itemstack, @Nonnull EnumFacing side) {
-        return isItemValidForSlot(i, itemstack);
+        IAdvancedBoundingBlock inv = getInv();
+        if (inv == null) {
+            return false;
+        }
+        
+        return inv.canInsertItem(i, itemstack, side);
     }
 
     @Override
@@ -217,7 +222,7 @@ public class TileEntityAdvancedBoundingBlock extends TileEntityBoundingBlock imp
             return false;
         }
 
-        return inv.canBoundExtract(getPos(), i, itemstack, side);
+        return inv.canExtractItem(i, itemstack, side);
     }
 
     @Override

--- a/src/main/java/mekanism/common/util/ChargeUtils.java
+++ b/src/main/java/mekanism/common/util/ChargeUtils.java
@@ -124,17 +124,17 @@ public final class ChargeUtils {
      * @return if the ItemStack can be discharged
      */
     public static boolean canBeDischarged(ItemStack itemstack) {
-        return (MekanismUtils.useIC2() && itemstack.getItem() instanceof IElectricItem && ((IElectricItem) itemstack
-              .getItem()).canProvideEnergy(itemstack)) ||
-              (itemstack.getItem() instanceof IEnergizedItem && ((IEnergizedItem) itemstack.getItem())
-                    .canSend(itemstack)) ||
-              (MekanismUtils.useRF() && itemstack.getItem() instanceof IEnergyContainerItem
-                    && ((IEnergyContainerItem) itemstack.getItem()).extractEnergy(itemstack, 1, true) != 0) ||
-              (MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null)
-                    && itemstack.getCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null).takePower(1, true) > 0) ||
-              (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null) && itemstack
-                    .getCapability(CapabilityEnergy.ENERGY, null).canExtract()) ||
-              itemstack.getItem() == Items.REDSTONE;
+        return MekanismUtils.useIC2() && ElectricItem.manager.discharge(itemstack, 1, 0, true, true, true) > 0
+                || (itemstack.getItem() instanceof IEnergizedItem
+                        && ((IEnergizedItem) itemstack.getItem()).canSend(itemstack)
+                        && ((IEnergizedItem) itemstack.getItem()).getEnergy(itemstack) > 0)
+                || (MekanismUtils.useRF() && itemstack.getItem() instanceof IEnergyContainerItem
+                        && ((IEnergyContainerItem) itemstack.getItem()).extractEnergy(itemstack, 1, true) != 0)
+                || (MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null)
+                        && itemstack.getCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null).takePower(1, true) > 0)
+                || (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null)
+                        && itemstack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(1, true) > 0)
+                || itemstack.getItem() == Items.REDSTONE;
     }
 
     /**
@@ -144,15 +144,17 @@ public final class ChargeUtils {
      * @return if the ItemStack can be discharged
      */
     public static boolean canBeCharged(ItemStack itemstack) {
-        return (MekanismUtils.useIC2() && ElectricItem.manager.getTier(itemstack) > 0) ||
-              (itemstack.getItem() instanceof IEnergizedItem && ((IEnergizedItem) itemstack.getItem())
-                    .canReceive(itemstack)) ||
-              (MekanismUtils.useRF() && itemstack.getItem() instanceof IEnergyContainerItem
-                    && ((IEnergyContainerItem) itemstack.getItem()).receiveEnergy(itemstack, 1, true) != 0) ||
-              (MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null)
-                    && itemstack.getCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null).givePower(1, true) > 0) ||
-              (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null) && itemstack
-                    .getCapability(CapabilityEnergy.ENERGY, null).canReceive());
+        return (MekanismUtils.useIC2() && ElectricItem.manager.charge(itemstack, 1, 0, true, true) > 0)
+                || (itemstack.getItem() instanceof IEnergizedItem
+                        && ((IEnergizedItem) itemstack.getItem()).canReceive(itemstack)
+                        && ((IEnergizedItem) itemstack.getItem())
+                                .getMaxEnergy(itemstack) < ((IEnergizedItem) itemstack.getItem()).getEnergy(itemstack))
+                || (MekanismUtils.useRF() && itemstack.getItem() instanceof IEnergyContainerItem
+                        && ((IEnergyContainerItem) itemstack.getItem()).receiveEnergy(itemstack, 1, true) > 0)
+                || (MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null)
+                        && itemstack.getCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null).givePower(1, true) > 0)
+                || (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null)
+                        && itemstack.getCapability(CapabilityEnergy.ENERGY, null).receiveEnergy(1, true) > 0);
     }
 
     /**

--- a/src/main/java/mekanism/common/util/ChargeUtils.java
+++ b/src/main/java/mekanism/common/util/ChargeUtils.java
@@ -118,43 +118,44 @@ public final class ChargeUtils {
     }
 
     /**
-     * Whether or not a defined ItemStack can be discharged for energy in some way.
+     * Whether or not a defined ItemStack can be discharged for energy in some way. Note: The ItemStack must also have
+     * energy to discharge.
      *
      * @param itemstack - ItemStack to check
      * @return if the ItemStack can be discharged
      */
     public static boolean canBeDischarged(ItemStack itemstack) {
-        return MekanismUtils.useIC2() && ElectricItem.manager.discharge(itemstack, 1, 0, true, true, true) > 0
-                || (itemstack.getItem() instanceof IEnergizedItem
-                        && ((IEnergizedItem) itemstack.getItem()).canSend(itemstack)
-                        && ((IEnergizedItem) itemstack.getItem()).getEnergy(itemstack) > 0)
-                || (MekanismUtils.useRF() && itemstack.getItem() instanceof IEnergyContainerItem
-                        && ((IEnergyContainerItem) itemstack.getItem()).extractEnergy(itemstack, 1, true) != 0)
-                || (MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null)
-                        && itemstack.getCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null).takePower(1, true) > 0)
-                || (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null)
-                        && itemstack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(1, true) > 0)
-                || itemstack.getItem() == Items.REDSTONE;
+        return MekanismUtils.useIC2() && ElectricItem.manager.discharge(itemstack, 1, 0, true, true, true) > 0 || (
+              itemstack.getItem() instanceof IEnergizedItem && ((IEnergizedItem) itemstack.getItem()).canSend(itemstack)
+                    && ((IEnergizedItem) itemstack.getItem()).getEnergy(itemstack) > 0) || (MekanismUtils.useRF()
+              && itemstack.getItem() instanceof IEnergyContainerItem
+              && ((IEnergyContainerItem) itemstack.getItem()).extractEnergy(itemstack, 1, true) != 0) || (
+              MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null)
+                    && itemstack.getCapability(Capabilities.TESLA_PRODUCER_CAPABILITY, null).takePower(1, true) > 0)
+              || (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null)
+              && itemstack.getCapability(CapabilityEnergy.ENERGY, null).extractEnergy(1, true) > 0)
+              || itemstack.getItem() == Items.REDSTONE;
     }
 
     /**
-     * Whether or not a defined ItemStack can be charged with energy in some way.
+     * Whether or not a defined ItemStack can be charged with energy in some way. Note: The ItemStack must also have
+     * room for more energy.
      *
      * @param itemstack - ItemStack to check
      * @return if the ItemStack can be discharged
      */
     public static boolean canBeCharged(ItemStack itemstack) {
-        return (MekanismUtils.useIC2() && ElectricItem.manager.charge(itemstack, 1, 0, true, true) > 0)
-                || (itemstack.getItem() instanceof IEnergizedItem
-                        && ((IEnergizedItem) itemstack.getItem()).canReceive(itemstack)
-                        && ((IEnergizedItem) itemstack.getItem())
-                                .getMaxEnergy(itemstack) < ((IEnergizedItem) itemstack.getItem()).getEnergy(itemstack))
-                || (MekanismUtils.useRF() && itemstack.getItem() instanceof IEnergyContainerItem
-                        && ((IEnergyContainerItem) itemstack.getItem()).receiveEnergy(itemstack, 1, true) > 0)
-                || (MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null)
-                        && itemstack.getCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null).givePower(1, true) > 0)
-                || (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null)
-                        && itemstack.getCapability(CapabilityEnergy.ENERGY, null).receiveEnergy(1, true) > 0);
+        return (MekanismUtils.useIC2() && ElectricItem.manager.charge(itemstack, 1, 0, true, true) > 0) || (
+              itemstack.getItem() instanceof IEnergizedItem && ((IEnergizedItem) itemstack.getItem())
+                    .canReceive(itemstack)
+                    && ((IEnergizedItem) itemstack.getItem()).getMaxEnergy(itemstack) < ((IEnergizedItem) itemstack
+                    .getItem()).getEnergy(itemstack)) || (MekanismUtils.useRF() && itemstack
+              .getItem() instanceof IEnergyContainerItem
+              && ((IEnergyContainerItem) itemstack.getItem()).receiveEnergy(itemstack, 1, true) > 0) || (
+              MekanismUtils.useTesla() && itemstack.hasCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null)
+                    && itemstack.getCapability(Capabilities.TESLA_CONSUMER_CAPABILITY, null).givePower(1, true) > 0)
+              || (MekanismUtils.useForge() && itemstack.hasCapability(CapabilityEnergy.ENERGY, null)
+              && itemstack.getCapability(CapabilityEnergy.ENERGY, null).receiveEnergy(1, true) > 0);
     }
 
     /**


### PR DESCRIPTION
Fixed Logistical Transporters not sending stuff back to home locations. It looks like this was a bug introduced from a PR in the main branch from a while ago.
Also, fixed Digital Miner's charge slot inventory functionality by trashing ISidedInventory stuff in IAdvancedBoundingBlock