### PR TITLE
Introduce bounds to search for sparkles!

### DIFF
--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -1006,7 +1006,7 @@ public class ClientProxy extends CommonProxy {
             player.sendStatusMessage(
                   new TextComponentGroup(TextFormatting.BLUE).translation("chat.mek.multiblockformed"), true);
             if (client.enableMultiblockFormationParticles) {
-                new SparkleAnimation(tileEntity, checker).run();
+                new SparkleAnimation(tileEntity, 8, checker).run();
             }
         }
     }
@@ -1018,7 +1018,7 @@ public class ClientProxy extends CommonProxy {
             player.sendStatusMessage(
                   new TextComponentGroup(TextFormatting.BLUE).translation("chat.mek.multiblockformed"), true);
             if (client.enableMultiblockFormationParticles) {
-                new SparkleAnimation(tileEntity, tile -> MultiblockManager.areEqual(tile, tileEntity)).run();
+                new SparkleAnimation(tileEntity, 8, tile -> MultiblockManager.areEqual(tile, tileEntity)).run();
             }
         }
     }

--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -146,6 +146,7 @@ import mekanism.common.item.ItemPortableTeleporter;
 import mekanism.common.item.ItemSeismicReader;
 import mekanism.common.item.ItemWalkieTalkie;
 import mekanism.common.multiblock.MultiblockManager;
+import mekanism.common.multiblock.UpdateProtocol.NodeChecker;
 import mekanism.common.network.PacketPortableTeleporter.PortableTeleporterMessage;
 import mekanism.common.tile.TileEntityAdvancedFactory;
 import mekanism.common.tile.TileEntityAmbientAccumulator;
@@ -999,29 +1000,27 @@ public class ClientProxy extends CommonProxy {
         }
     }
 
-    @Override
-    public void doGenericSparkle(TileEntity tileEntity, INodeChecker checker) {
+    private void doSparkle(TileEntity tileEntity, SparkleAnimation anim) {
         EntityPlayerSP player = Minecraft.getMinecraft().player;
         if (tileEntity.getPos().distanceSq(player.getPosition()) <= 100) {
             player.sendStatusMessage(
                   new TextComponentGroup(TextFormatting.BLUE).translation("chat.mek.multiblockformed"), true);
             if (client.enableMultiblockFormationParticles) {
-                new SparkleAnimation(tileEntity, 8, checker).run();
+                anim.run();
             }
         }
     }
 
     @Override
-    public void doMultiblockSparkle(final TileEntityMultiblock<?> tileEntity) {
-        EntityPlayerSP player = Minecraft.getMinecraft().player;
-        if (tileEntity.getPos().distanceSq(player.getPosition()) <= 100) {
-            player.sendStatusMessage(
-                  new TextComponentGroup(TextFormatting.BLUE).translation("chat.mek.multiblockformed"), true);
-            if (client.enableMultiblockFormationParticles) {
-                new SparkleAnimation(tileEntity, 8, tile -> MultiblockManager.areEqual(tile, tileEntity)).run();
-            }
-        }
+    public void doMultiblockSparkle(TileEntity tileEntity, BlockPos renderLoc, int length, int width, int height, INodeChecker checker) {
+        doSparkle(tileEntity, new SparkleAnimation(tileEntity, renderLoc, length, width, height, checker));
     }
+
+
+    public void doMultiblockSparkle(TileEntity tileEntity, BlockPos corner1, BlockPos corner2, INodeChecker checker) {
+        doSparkle(tileEntity, new SparkleAnimation(tileEntity, corner1, corner2, checker));
+    }
+
 
     @Override
     public void init() {

--- a/src/main/java/mekanism/client/ClientProxy.java
+++ b/src/main/java/mekanism/client/ClientProxy.java
@@ -1002,11 +1002,13 @@ public class ClientProxy extends CommonProxy {
 
     private void doSparkle(TileEntity tileEntity, SparkleAnimation anim) {
         EntityPlayerSP player = Minecraft.getMinecraft().player;
-        if (tileEntity.getPos().distanceSq(player.getPosition()) <= 100) {
-            player.sendStatusMessage(
-                  new TextComponentGroup(TextFormatting.BLUE).translation("chat.mek.multiblockformed"), true);
+        // If player is within 16 blocks (256 = 16^2), show the status message/sparkles
+        if (tileEntity.getPos().distanceSq(player.getPosition()) <= 256) {
             if (client.enableMultiblockFormationParticles) {
                 anim.run();
+            } else {
+                player.sendStatusMessage(
+                      new TextComponentGroup(TextFormatting.BLUE).translation("chat.mek.multiblockformed"), true);
             }
         }
     }

--- a/src/main/java/mekanism/client/SparkleAnimation.java
+++ b/src/main/java/mekanism/client/SparkleAnimation.java
@@ -38,7 +38,6 @@ public class SparkleAnimation {
 
 
     public void run() {
-        long start = System.nanoTime();
         if (general.dynamicTankEasterEgg) {
             tile.getWorld()
                   .playSound(null, tile.getPos().getX(), tile.getPos().getY(), tile.getPos().getZ(),
@@ -50,7 +49,6 @@ public class SparkleAnimation {
 
         World world = tile.getWorld();
         ThreadLocalRandom random = ThreadLocalRandom.current();
-        int sparkles = 0;
 
         while (itr.hasNext()) {
             BlockPos pos = itr.next();
@@ -64,7 +62,6 @@ public class SparkleAnimation {
             }
 
             for (int i = 0; i < 2; i++) {
-                sparkles++;
                 world.spawnParticle(EnumParticleTypes.REDSTONE, pos.getX() + random.nextDouble(),
                       pos.getY() + random.nextDouble(), pos.getZ() + -.01, 0, 0, 0);
                 world.spawnParticle(EnumParticleTypes.REDSTONE, pos.getX() + random.nextDouble(),
@@ -75,9 +72,6 @@ public class SparkleAnimation {
                       pos.getY() + random.nextDouble(), pos.getZ() + random.nextDouble(), 0, 0, 0);
             }
         }
-
-        long elapsed = System.nanoTime() - start;
-        Mekanism.logger.info("Generated {} sparkles in {} ms", sparkles, elapsed / 1000000d);
     }
 
     public interface INodeChecker {

--- a/src/main/java/mekanism/common/CommonProxy.java
+++ b/src/main/java/mekanism/common/CommonProxy.java
@@ -57,6 +57,7 @@ import mekanism.common.inventory.container.robit.ContainerRobitMain;
 import mekanism.common.inventory.container.robit.ContainerRobitRepair;
 import mekanism.common.inventory.container.robit.ContainerRobitSmelting;
 import mekanism.common.item.ItemPortableTeleporter;
+import mekanism.common.multiblock.UpdateProtocol.NodeChecker;
 import mekanism.common.network.PacketPortableTeleporter.PortableTeleporterMessage;
 import mekanism.common.tile.TileEntityChanceMachine;
 import mekanism.common.tile.TileEntityChemicalCrystallizer;
@@ -510,16 +511,15 @@ public class CommonProxy implements IGuiProvider {
     }
 
     /**
-     * Does a generic creation animation, starting from the rendering block.
+     * Does the multiblock creation animation, starting from the rendering block.
      */
-    public void doGenericSparkle(TileEntity tileEntity, INodeChecker checker) {
-    }
+    public void doMultiblockSparkle(TileEntity tileEntity, BlockPos corner1, BlockPos corner2, INodeChecker checker) {}
 
     /**
      * Does the multiblock creation animation, starting from the rendering block.
      */
-    public void doMultiblockSparkle(TileEntityMultiblock<?> tileEntity) {
-    }
+    public void doMultiblockSparkle(TileEntity tileEntity, BlockPos renderLoc, int length, int width, int height,
+          INodeChecker checker) {}
 
     @Override
     public Object getClientGui(int ID, EntityPlayer player, World world, BlockPos pos) {

--- a/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
+++ b/src/main/java/mekanism/common/tile/TileEntityMultiblock.java
@@ -79,7 +79,8 @@ public abstract class TileEntityMultiblock<T extends SynchronizedData<T>> extend
 
             if (structure != null && clientHasStructure && isRendering) {
                 if (!prevStructure) {
-                    Mekanism.proxy.doMultiblockSparkle(this);
+                    Mekanism.proxy.doMultiblockSparkle(this, structure.renderLocation.getPos(), structure.volLength,
+                          structure.volWidth, structure.volHeight, tile -> MultiblockManager.areEqual(this, tile));
                 }
             }
 

--- a/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
+++ b/src/main/java/mekanism/common/tile/TileEntityThermalEvaporationController.java
@@ -26,12 +26,15 @@ import mekanism.common.util.InventoryUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.TileUtils;
 import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.EnumFacing.Axis;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -501,7 +504,13 @@ public class TileEntityThermalEvaporationController extends TileEntityThermalEva
                 MekanismUtils.updateBlock(world, getPos());
 
                 if (structured) {
-                    Mekanism.proxy.doGenericSparkle(this, tile -> tile instanceof TileEntityThermalEvaporationBlock);
+                    // Calculate the two corners of the evap tower using the render location as basis (which is the
+                    // lowest rightmost corner inside the tower, relative to the controller).
+                    BlockPos corner1 = getRenderLocation().getPos().offset(facing).offset(facing.rotateYCCW()).down();
+                    BlockPos corner2 = corner1.offset(facing.getOpposite(), 3).offset(facing.rotateYCCW().getOpposite(), 3).up(height-1);
+                    // Use the corners to spin up the sparkle
+                    Mekanism.proxy.doMultiblockSparkle(this, corner1, corner2,
+                          tile -> tile instanceof  TileEntityThermalEvaporationBlock);
                 }
 
                 clientStructured = structured;

--- a/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
+++ b/src/main/java/mekanism/generators/common/tile/reactor/TileEntityReactorController.java
@@ -19,6 +19,7 @@ import mekanism.generators.common.FusionReactor;
 import mekanism.generators.common.item.ItemHohlraum;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.audio.ISound;
+import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
@@ -26,6 +27,8 @@ import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.SoundEvent;
 import net.minecraft.util.math.AxisAlignedBB;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3i;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidTank;
@@ -257,7 +260,9 @@ public class TileEntityReactorController extends TileEntityReactorBlock implemen
 
             if (formed) {
                 if (getReactor() == null || !getReactor().formed) {
-                    Mekanism.proxy.doGenericSparkle(this, tile -> tile instanceof TileEntityReactorBlock);
+                    BlockPos corner = getPos().subtract(new Vec3i(2, 4, 2));
+                    Mekanism.proxy.doMultiblockSparkle(this, corner, 5, 5, 6,
+                          tile -> tile instanceof TileEntityReactorBlock);
                 }
 
                 if (getReactor() == null) {


### PR DESCRIPTION
In c368692a3, the recursive search was changed to iterative. The big problem with both approaches, however is that as more and more positions are scanned, it takes longer to actually determine if the position was scanned. This PR introduces a radius which is used to get a fixed set of block positions to scan and as each position is scanned, particles are generated. This reduces memory footprint and avoids a O(n^2) search.

Not quite working yet; pending me not being on a plane. :)