### PR TITLE
Port factory insertion

### DIFF
--- a/src/main/java/mekanism/common/inventory/container/ContainerFactory.java
+++ b/src/main/java/mekanism/common/inventory/container/ContainerFactory.java
@@ -201,7 +201,7 @@ public class ContainerFactory extends ContainerMekanism<TileEntityFactory> {
                   .getAnyRecipe(stack, inventorySlots.get(4).getStack(), tileEntity.gasTank.getGasType(),
                         tileEntity.infuseStored);
             if (matchingRecipe.recipeOutput instanceof ItemStackOutput) {
-                return ItemStack.areItemsEqual(((ItemStackOutput) matchingRecipe.recipeOutput).output, stack);
+                return ItemStack.areItemsEqual(((ItemStackOutput) matchingRecipe.recipeOutput).output, outputSlotStack);
             }
             return super.isItemValid(stack);
         }

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -373,7 +373,6 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
         return configComponent.hasSideForData(TransmissionType.ENERGY, facing, 1, side);
     }
 
-    //can be optimised a lot to be linear
     public void sortInventory() {
         if (sorting) {
             int[] inputSlots;

--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -499,6 +499,22 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
     }
 
     @Override
+    public boolean canInsertItem(int slotID, @Nonnull ItemStack itemstack, @Nonnull EnumFacing side) {
+        if (slotID == 1) {
+            return ChargeUtils.canBeDischarged(itemstack);
+        } else if (isInputSlot(slotID)) {
+            return inputProducesOutput(itemstack, inventory.get(tier.processes + slotID));
+        }
+        //TODO: Only allow inserting into extra slot if it can go in
+        return super.canInsertItem(slotID, itemstack, side);
+    }
+
+    private boolean isInputSlot(int slotID) {
+        return slotID >= 5 && (tier == FactoryTier.BASIC ? slotID <= 7
+              : tier == FactoryTier.ADVANCED ? slotID <= 9 : tier == FactoryTier.ELITE && slotID <= 11);
+    }
+
+    @Override
     public boolean isItemValidForSlot(int slotID, @Nonnull ItemStack itemstack) {
         if (tier == FactoryTier.BASIC) {
             if (slotID >= 8 && slotID <= 10) {

--- a/src/main/java/mekanism/common/util/StackUtils.java
+++ b/src/main/java/mekanism/common/util/StackUtils.java
@@ -6,7 +6,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.oredict.OreDictionary;
-import org.apache.commons.lang3.tuple.Pair;
 
 public final class StackUtils {
 
@@ -16,14 +15,6 @@ public final class StackUtils {
             return false;
         }
         return stack1.getItem() != stack2.getItem() || stack1.getItemDamage() != stack2.getItemDamage();
-    }
-
-    //only used in factory
-    //could be inlined at this point probably
-    public static Pair<ItemStack, ItemStack> even(ItemStack stack1, ItemStack stack2) {
-        int count = stack1.getCount() + stack2.getCount();
-        ItemStack stack = stack1.isEmpty() ? stack2 : stack1;
-        return Pair.of(size(stack, (count + 1)/2), size(stack, count/2));
     }
 
     //ignores count


### PR DESCRIPTION
Changes:
- Ported and fixed `dfd5252cd`. In mainline it currently checks to compare if the new "input" stack is equal to what the recipe for that "input" will produce, makes it so that if you try to insert more iron ore when you have iron as an output it doesn't work. (This bug is fixed in this port)
- Improved performance of factory auto sort from `O(n^2)` to `O(n)`. This means worst case for an elite factory it does `14` checks instead of `49`, and if ultimate factories ever get added it will only have to do `18` instead of `81`.
- Don't allow auto sorting into slots where they can't process to the existing output.
- Don't allow inserting into slots where the item won't be able to be processed into the existing output.