### PR TITLE
Port some mod compat/hook stuff

### DIFF
--- a/etc/core/mcmod.info
+++ b/etc/core/mcmod.info
@@ -21,7 +21,6 @@
       "ic2",
       "computercraft",
       "galaticraft api",
-      "metallurgy",
       "crafttweaker",
       "cofhcore",
       "cyclicmagic"

--- a/etc/core/mcmod.info
+++ b/etc/core/mcmod.info
@@ -23,7 +23,8 @@
       "galaticraft api",
       "metallurgy",
       "crafttweaker",
-      "cofhcore"
+      "cofhcore",
+      "cyclicmagic"
     ],
     "requiredMods": [
       "forge@[14.23.2.2639,)"

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -327,6 +327,7 @@ public class Mekanism {
         event.getRegistry().register(new BinRecipe());
         addRecipes();
         OreDictManager.init();
+        hooks.hookRecipes();
     }
 
     /**
@@ -952,6 +953,8 @@ public class Mekanism {
                     .setTranslationKey("obsidian"));
 
         Capabilities.registerCapabilities();
+
+        hooks.hookPreInit();
     }
 
     @EventHandler
@@ -994,22 +997,7 @@ public class Mekanism {
         //Load this module
         registerTileEntities();
 
-        //Integrate with Waila
-        FMLInterModComms.sendMessage(MekanismHooks.WAILA_MOD_ID, "register",
-              "mekanism.common.integration.WailaDataProvider.register");
-
-        //Register TOP handler
-        FMLInterModComms
-              .sendFunctionMessage("theoneprobe", "getTheOneProbe", "mekanism.common.integration.TOPProvider");
-
-        //Integrate with OpenComputers
-        if (Loader.isModLoaded(MekanismHooks.OPENCOMPUTERS_MOD_ID)) {
-            hooks.loadOCDrivers();
-        }
-
-        if (Loader.isModLoaded(MekanismHooks.APPLIED_ENERGISTICS_2_MOD_ID)) {
-            hooks.registerAE2P2P();
-        }
+        hooks.hookInit();
 
         //Packet registrations
         packetHandler.initialize();
@@ -1037,7 +1025,7 @@ public class Mekanism {
             Recipe.ENERGIZED_SMELTER.put(recipe);
         }
 
-        hooks.hook();
+        hooks.hookPostInit();
 
         MinecraftForge.EVENT_BUS.post(new BoxBlacklistEvent());
 

--- a/src/main/java/mekanism/common/OreDictCache.java
+++ b/src/main/java/mekanism/common/OreDictCache.java
@@ -40,11 +40,7 @@ public final class OreDictCache {
         return ret;
     }
 
-    public static List<ItemStack> getOreDictStacks(String oreName, boolean forceBlock) {
-        if (oreDictStacks.get(oreName) != null) {
-            return oreDictStacks.get(oreName);
-        }
-
+    public static List<String> getOreDictKeys(String oreName) {
         List<String> keys = new ArrayList<>();
 
         for (String s : OreDictionary.getOreNames()) {
@@ -68,6 +64,15 @@ public final class OreDictCache {
                 }
             }
         }
+        return keys;
+    }
+
+    public static List<ItemStack> getOreDictStacks(String oreName, boolean forceBlock) {
+        if (oreDictStacks.get(oreName) != null) {
+            return oreDictStacks.get(oreName);
+        }
+
+        List<String> keys = getOreDictKeys(oreName);
 
         List<ItemStack> stacks = new ArrayList<>();
 

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -24,15 +24,20 @@ import mekanism.common.integration.computer.OCDriver;
 import mekanism.common.integration.crafttweaker.CrafttweakerIntegration;
 import mekanism.common.integration.wrenches.Wrenches;
 import mekanism.common.recipe.RecipeHandler;
+import mekanism.common.util.StackUtils;
 import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.fml.common.event.FMLInterModComms;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.oredict.OreDictionary;
 
 /**
  * Hooks for Mekanism. Use to grab items or blocks out of different mods.
@@ -48,10 +53,12 @@ public final class MekanismHooks {
     public static final String TESLA_MOD_ID = "tesla";
     public static final String MCMULTIPART_MOD_ID = "mcmultipart";
     public static final String REDSTONEFLUX_MOD_ID = "redstoneflux";
+    public static final String METALLURGY_MOD_ID = "metallurgy";
     public static final String OPENCOMPUTERS_MOD_ID = "opencomputers";
     public static final String GALACTICRAFT_MOD_ID = "Galacticraft API";
     public static final String WAILA_MOD_ID = "Waila";
     public static final String BUILDCRAFT_MOD_ID = "BuildCraft";
+    public static final String CYCLIC_MOD_ID = "cyclicmagic";
 
     public boolean IC2Loaded = false;
     public boolean CCLoaded = false;
@@ -59,16 +66,24 @@ public final class MekanismHooks {
     public boolean TeslaLoaded = false;
     public boolean MCMPLoaded = false;
     public boolean RFLoaded = false;
+    public boolean MetallurgyLoaded = false;
+    public boolean CyclicLoaded = false;
 
     public void hook() {
         if (Loader.isModLoaded(IC2_MOD_ID)) {
             IC2Loaded = true;
+            hookIC2Recipes();
+            Mekanism.logger.info("Hooked into IC2 successfully.");
         }
         if (Loader.isModLoaded(COMPUTERCRAFT_MOD_ID)) {
             CCLoaded = true;
+            loadCCPeripheralProviders();
+            Mekanism.logger.info("Hooked into Computer Craft successfully.");
         }
         if (Loader.isModLoaded(APPLIED_ENERGISTICS_2_MOD_ID)) {
             AE2Loaded = true;
+            registerAE2Recipes();
+            Mekanism.logger.info("Hooked into AE2 successfully.");
         }
         if (Loader.isModLoaded(TESLA_MOD_ID)) {
             TeslaLoaded = true;
@@ -79,18 +94,15 @@ public final class MekanismHooks {
         if (Loader.isModLoaded(REDSTONEFLUX_MOD_ID)) {
             RFLoaded = true;
         }
-
-        if (IC2Loaded) {
-            hookIC2Recipes();
-            Mekanism.logger.info("Hooked into IC2 successfully.");
+        if (Loader.isModLoaded(METALLURGY_MOD_ID)) {
+            MetallurgyLoaded = true;
+            addMetallurgy();
+            Mekanism.logger.info("Hooked into Metallurgy successfully.");
         }
-
-        if (CCLoaded) {
-            loadCCPeripheralProviders();
-        }
-
-        if (AE2Loaded) {
-            registerAE2Recipes();
+        if (Loader.isModLoaded(CYCLIC_MOD_ID)) {
+            CyclicLoaded = true;
+            registerCyclicRecipes();
+            Mekanism.logger.info("Hooked into Cyclic successfully.");
         }
 
         if (Loader.isModLoaded("crafttweaker")) {
@@ -160,6 +172,86 @@ public final class MekanismHooks {
             Driver.add(new OCDriver());
         } catch (Exception ignored) {
         }
+    }
+
+    private void registerCyclicCombinerOreRecipe(String ore, int quantity, ItemStack extra, String outputName) {
+        Item outputItem = ForgeRegistries.ITEMS.getValue(new ResourceLocation(CYCLIC_MOD_ID, outputName));
+        if (outputItem != null) {
+            for (ItemStack stack : OreDictionary.getOres(ore)) {
+                RecipeHandler.addCombinerRecipe(StackUtils.size(stack, quantity), extra, new ItemStack(outputItem));
+            }
+        }
+    }
+
+    private void registerCyclicCombinerRecipe(ItemStack input, ItemStack extra, String outputName) {
+        Item outputItem = ForgeRegistries.ITEMS.getValue(new ResourceLocation(CYCLIC_MOD_ID, outputName));
+        if (outputItem != null) {
+            RecipeHandler.addCombinerRecipe(input, extra, new ItemStack(outputItem));
+        }
+    }
+
+    private void registerCyclicRecipes() {
+        ItemStack netherrack = new ItemStack(Item.getItemFromBlock(Blocks.NETHERRACK));
+        registerCyclicCombinerRecipe(new ItemStack(Items.REDSTONE, 3), netherrack, "nether_redstone_ore");
+        registerCyclicCombinerOreRecipe("dustIron", 8, netherrack, "nether_iron_ore");
+        registerCyclicCombinerOreRecipe("dustGold", 8, netherrack, "nether_gold_ore");
+        registerCyclicCombinerRecipe(new ItemStack(Items.COAL, 3), netherrack, "nether_coal_ore");
+        registerCyclicCombinerRecipe(new ItemStack(Items.DYE, 5, 4), netherrack, "nether_lapis_ore");
+        registerCyclicCombinerRecipe(new ItemStack(Items.EMERALD, 3), netherrack, "nether_emerald_ore");
+        registerCyclicCombinerOreRecipe("dustDiamond", 3, netherrack, "nether_diamond_ore");
+
+        ItemStack end_stone = new ItemStack(Item.getItemFromBlock(Blocks.END_STONE));
+        registerCyclicCombinerRecipe(new ItemStack(Items.REDSTONE, 3), end_stone, "end_redstone_ore");
+        registerCyclicCombinerRecipe(new ItemStack(Items.COAL, 3), end_stone, "end_coal_ore");
+        registerCyclicCombinerRecipe(new ItemStack(Items.DYE, 5, 4), end_stone, "end_lapis_ore");
+        registerCyclicCombinerRecipe(new ItemStack(Items.EMERALD, 3), end_stone, "end_emerald_ore");
+        registerCyclicCombinerOreRecipe("dustDiamond", 3, end_stone, "end_diamond_ore");
+        registerCyclicCombinerOreRecipe("dustGold", 8, end_stone, "end_gold_ore");
+        registerCyclicCombinerOreRecipe("dustIron", 8, end_stone, "end_iron_ore");
+    }
+
+    private void addMetallurgy() {
+        OreDictManager.addStandardOredictMetal("Adamantine");
+        OreDictManager.addStandardOredictMetal("Alduorite");
+        OreDictManager.addStandardOredictMetal("Angmallen");
+        OreDictManager.addStandardOredictMetal("AstralSilver");
+        OreDictManager.addStandardOredictMetal("Atlarus");
+        OreDictManager.addStandardOredictMetal("Amordrine");
+        OreDictManager.addStandardOredictMetal("BlackSteel");
+        OreDictManager.addStandardOredictMetal("Brass");
+        OreDictManager.addStandardOredictMetal("Bronze");
+        OreDictManager.addStandardOredictMetal("Carmot");
+        OreDictManager.addStandardOredictMetal("Celenegil");
+        OreDictManager.addStandardOredictMetal("Ceruclase");
+        OreDictManager.addStandardOredictMetal("DamascusSteel");
+        OreDictManager.addStandardOredictMetal("DeepIron");
+        OreDictManager.addStandardOredictMetal("Desichalkos");
+        OreDictManager.addStandardOredictMetal("Electrum");
+        OreDictManager.addStandardOredictMetal("Eximite");
+        OreDictManager.addStandardOredictMetal("Haderoth");
+        OreDictManager.addStandardOredictMetal("Hepatizon");
+        OreDictManager.addStandardOredictMetal("Ignatius");
+        OreDictManager.addStandardOredictMetal("Infuscolium");
+        OreDictManager.addStandardOredictMetal("Inolashite");
+        OreDictManager.addStandardOredictMetal("Kalendrite");
+        OreDictManager.addStandardOredictMetal("Lemurite");
+        OreDictManager.addStandardOredictMetal("Manganese");
+        OreDictManager.addStandardOredictMetal("Meutoite");
+        OreDictManager.addStandardOredictMetal("Midasium");
+        OreDictManager.addStandardOredictMetal("Mithril");
+        OreDictManager.addStandardOredictMetal("Orichalcum");
+        OreDictManager.addStandardOredictMetal("Oureclase");
+        OreDictManager.addStandardOredictMetal("Prometheum");
+        OreDictManager.addStandardOredictMetal("Quicksilver");
+        OreDictManager.addStandardOredictMetal("Rubracium");
+        OreDictManager.addStandardOredictMetal("Sanguinite");
+        OreDictManager.addStandardOredictMetal("ShadowIron");
+        OreDictManager.addStandardOredictMetal("ShadowSteel");
+        OreDictManager.addStandardOredictMetal("Tartarite");
+        OreDictManager.addStandardOredictMetal("Vulcanite");
+        OreDictManager.addStandardOredictMetal("Vyroxeres");
+        OreDictManager.addStandardOredictMetal("Zinc");
+
     }
 
     public void addPulverizerRecipe(ItemStack input, ItemStack output, int energy) {

--- a/src/main/java/mekanism/common/integration/MekanismHooks.java
+++ b/src/main/java/mekanism/common/integration/MekanismHooks.java
@@ -53,7 +53,6 @@ public final class MekanismHooks {
     public static final String TESLA_MOD_ID = "tesla";
     public static final String MCMULTIPART_MOD_ID = "mcmultipart";
     public static final String REDSTONEFLUX_MOD_ID = "redstoneflux";
-    public static final String METALLURGY_MOD_ID = "metallurgy";
     public static final String OPENCOMPUTERS_MOD_ID = "opencomputers";
     public static final String GALACTICRAFT_MOD_ID = "Galacticraft API";
     public static final String WAILA_MOD_ID = "Waila";
@@ -66,7 +65,6 @@ public final class MekanismHooks {
     public boolean TeslaLoaded = false;
     public boolean MCMPLoaded = false;
     public boolean RFLoaded = false;
-    public boolean MetallurgyLoaded = false;
     public boolean CyclicLoaded = false;
 
     public void hook() {
@@ -93,11 +91,6 @@ public final class MekanismHooks {
         }
         if (Loader.isModLoaded(REDSTONEFLUX_MOD_ID)) {
             RFLoaded = true;
-        }
-        if (Loader.isModLoaded(METALLURGY_MOD_ID)) {
-            MetallurgyLoaded = true;
-            addMetallurgy();
-            Mekanism.logger.info("Hooked into Metallurgy successfully.");
         }
         if (Loader.isModLoaded(CYCLIC_MOD_ID)) {
             CyclicLoaded = true;
@@ -208,50 +201,6 @@ public final class MekanismHooks {
         registerCyclicCombinerOreRecipe("dustDiamond", 3, end_stone, "end_diamond_ore");
         registerCyclicCombinerOreRecipe("dustGold", 8, end_stone, "end_gold_ore");
         registerCyclicCombinerOreRecipe("dustIron", 8, end_stone, "end_iron_ore");
-    }
-
-    private void addMetallurgy() {
-        OreDictManager.addStandardOredictMetal("Adamantine");
-        OreDictManager.addStandardOredictMetal("Alduorite");
-        OreDictManager.addStandardOredictMetal("Angmallen");
-        OreDictManager.addStandardOredictMetal("AstralSilver");
-        OreDictManager.addStandardOredictMetal("Atlarus");
-        OreDictManager.addStandardOredictMetal("Amordrine");
-        OreDictManager.addStandardOredictMetal("BlackSteel");
-        OreDictManager.addStandardOredictMetal("Brass");
-        OreDictManager.addStandardOredictMetal("Bronze");
-        OreDictManager.addStandardOredictMetal("Carmot");
-        OreDictManager.addStandardOredictMetal("Celenegil");
-        OreDictManager.addStandardOredictMetal("Ceruclase");
-        OreDictManager.addStandardOredictMetal("DamascusSteel");
-        OreDictManager.addStandardOredictMetal("DeepIron");
-        OreDictManager.addStandardOredictMetal("Desichalkos");
-        OreDictManager.addStandardOredictMetal("Electrum");
-        OreDictManager.addStandardOredictMetal("Eximite");
-        OreDictManager.addStandardOredictMetal("Haderoth");
-        OreDictManager.addStandardOredictMetal("Hepatizon");
-        OreDictManager.addStandardOredictMetal("Ignatius");
-        OreDictManager.addStandardOredictMetal("Infuscolium");
-        OreDictManager.addStandardOredictMetal("Inolashite");
-        OreDictManager.addStandardOredictMetal("Kalendrite");
-        OreDictManager.addStandardOredictMetal("Lemurite");
-        OreDictManager.addStandardOredictMetal("Manganese");
-        OreDictManager.addStandardOredictMetal("Meutoite");
-        OreDictManager.addStandardOredictMetal("Midasium");
-        OreDictManager.addStandardOredictMetal("Mithril");
-        OreDictManager.addStandardOredictMetal("Orichalcum");
-        OreDictManager.addStandardOredictMetal("Oureclase");
-        OreDictManager.addStandardOredictMetal("Prometheum");
-        OreDictManager.addStandardOredictMetal("Quicksilver");
-        OreDictManager.addStandardOredictMetal("Rubracium");
-        OreDictManager.addStandardOredictMetal("Sanguinite");
-        OreDictManager.addStandardOredictMetal("ShadowIron");
-        OreDictManager.addStandardOredictMetal("ShadowSteel");
-        OreDictManager.addStandardOredictMetal("Tartarite");
-        OreDictManager.addStandardOredictMetal("Vulcanite");
-        OreDictManager.addStandardOredictMetal("Vyroxeres");
-        OreDictManager.addStandardOredictMetal("Zinc");
-
     }
 
     public void addPulverizerRecipe(ItemStack input, ItemStack output, int energy) {

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -1,7 +1,6 @@
 package mekanism.common.integration;
 
 import ic2.api.recipe.Recipes;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nonnull;
@@ -12,6 +11,7 @@ import mekanism.api.infuse.InfuseRegistry;
 import mekanism.common.Mekanism;
 import mekanism.common.MekanismFluids;
 import mekanism.common.MekanismItems;
+import mekanism.common.OreDictCache;
 import mekanism.common.Resource;
 import mekanism.common.config.MekanismConfig.general;
 import mekanism.common.recipe.RecipeHandler;
@@ -31,9 +31,6 @@ import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.oredict.OreDictionary;
 
 public final class OreDictManager {
-
-    private static final List<String> minorCompat = Arrays
-          .asList("Nickel", "Aluminum", "Uranium", "Draconium", "Platinum", "Iridium");
 
     public static void init() {
         addLogRecipes();
@@ -132,7 +129,16 @@ public final class OreDictManager {
             }
         }
 
-        minorCompat.forEach(OreDictManager::addStandardOredictMetal);
+        List<String> oreDictStacks = OreDictCache.getOreDictKeys("ore*");
+        oreDictStacks.forEach(OreDictManager::addStandardOredictMetal);
+
+        for (ItemStack ore : OreDictionary.getOres("orePhosphorite")) {
+            try {
+                RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1),
+                      StackUtils.size(OreDictionary.getOres("dustPhosphorus").get(0), 2));
+            } catch (Exception ignored) {
+            }
+        }
 
         for (ItemStack ore : OreDictionary.getOres("oreYellorite")) {
             try {
@@ -277,9 +283,10 @@ public final class OreDictManager {
         }
     }
 
-    public static void addStandardOredictMetal(String suffix) {
+    public static void addStandardOredictMetal(String oreDictEntry) {
+        String suffix = oreDictEntry.replaceFirst("ore", "");
         NonNullList<ItemStack> dusts = OreDictionary.getOres("dust" + suffix);
-        NonNullList<ItemStack> ores = OreDictionary.getOres("ore" + suffix);
+        NonNullList<ItemStack> ores = OreDictionary.getOres(oreDictEntry);
         if (dusts.size() > 0) {
             for (ItemStack ore : ores) {
                 RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), StackUtils.size(dusts.get(0), 2));

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -26,6 +26,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -131,31 +132,7 @@ public final class OreDictManager {
             }
         }
 
-        for (String s : minorCompat) {
-            for (ItemStack ore : OreDictionary.getOres("ore" + s)) {
-                try {
-                    RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1),
-                          StackUtils.size(OreDictionary.getOres("dust" + s).get(0), 2));
-                } catch (Exception ignored) {
-                }
-            }
-
-            for (ItemStack ore : OreDictionary.getOres("ingot" + s)) {
-                try {
-                    RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1),
-                          StackUtils.size(OreDictionary.getOres("dust" + s).get(0), 1));
-                } catch (Exception ignored) {
-                }
-            }
-
-            for (ItemStack ore : OreDictionary.getOres("dust" + s)) {
-                try {
-                    RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), new ItemStack(Blocks.COBBLESTONE),
-                          StackUtils.size(OreDictionary.getOres("ore" + s).get(0), 1));
-                } catch (Exception ignored) {
-                }
-            }
-        }
+        minorCompat.forEach(OreDictManager::addStandardOredictMetal);
 
         for (ItemStack ore : OreDictionary.getOres("oreYellorite")) {
             try {
@@ -297,6 +274,27 @@ public final class OreDictManager {
                 }
             }
         } catch (Exception ignored) {
+        }
+    }
+
+    public static void addStandardOredictMetal(String suffix) {
+        NonNullList<ItemStack> dusts = OreDictionary.getOres("dust" + suffix);
+        NonNullList<ItemStack> ores = OreDictionary.getOres("ore" + suffix);
+        if (dusts.size() > 0) {
+            for (ItemStack ore : ores) {
+                RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), StackUtils.size(dusts.get(0), 2));
+            }
+
+            for (ItemStack ore : OreDictionary.getOres("ingot" + suffix)) {
+                RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), StackUtils.size(dusts.get(0), 1));
+            }
+        }
+
+        if (ores.size() > 0) {
+            for (ItemStack ore : dusts) {
+                RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), new ItemStack(Blocks.COBBLESTONE),
+                      StackUtils.size(ores.get(0), 1));
+            }
         }
     }
 


### PR DESCRIPTION
Rewrote the metallurgy ore doubling compat to use an automated system rather than having specific integration. Note: This does not work until Metallurgy releases a new build including this commit: https://github.com/Davoleo/Metallurgy-4-Reforged/commit/ebfc835a288754f3d53c9a4c6f5d346a4d0aba82 but I tested the dev build and it works properly with the version of Metallurgy that registers things at the correct times.

The rewrite of the metallurgy ore doubling removes the need for these two commits:
```
d2f0c24e5
847e78004
```

The new method also adds compat with some misc ores that previously did not have any for doubling (such as some of the ones from tech reborn).

Also ported the cyclic integration from #5201 made up of these commits:
```
3456396d7
fd638902a
26abf5086
```

Rewrote parts of the hook system so that things happen at the proper time, so that recipes added by hooks can be removed by CraftTweaker instead of adding them a lot later than the recipe registry revent.