### PR TITLE
Clamp int for forge energy wrapper

### DIFF
--- a/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyItemWrapper.java
+++ b/src/main/java/mekanism/common/integration/forgeenergy/ForgeEnergyItemWrapper.java
@@ -3,6 +3,7 @@ package mekanism.common.integration.forgeenergy;
 import mekanism.api.energy.IEnergizedItem;
 import mekanism.common.capabilities.ItemCapabilityWrapper.ItemCapability;
 import mekanism.common.config.MekanismConfig.general;
+import mekanism.common.util.MekanismUtils;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
@@ -52,12 +53,12 @@ public class ForgeEnergyItemWrapper extends ItemCapability implements IEnergySto
 
     @Override
     public int getEnergyStored() {
-        return (int) Math.round(getItem().getEnergy(getStack()) * general.TO_FORGE);
+        return MekanismUtils.clampToInt(Math.round(getItem().getEnergy(getStack()) * general.TO_FORGE));
     }
 
     @Override
     public int getMaxEnergyStored() {
-        return (int) Math.round(getItem().getMaxEnergy(getStack()) * general.TO_FORGE);
+        return MekanismUtils.clampToInt(Math.round(getItem().getMaxEnergy(getStack()) * general.TO_FORGE));
     }
 
     @Override

--- a/src/main/java/mekanism/common/util/MekanismUtils.java
+++ b/src/main/java/mekanism/common/util/MekanismUtils.java
@@ -889,7 +889,7 @@ public final class MekanismUtils {
             renderer = stack.getItem().getFontRenderer(stack);
         }
 
-        if(renderer != null) {
+        if (renderer != null) {
             return renderer.listFormattedStringToWidth(s, 200);
         } else {
             return Collections.emptyList();
@@ -1115,6 +1115,29 @@ public final class MekanismUtils {
     public static TileEntity getTileEntitySafe(IBlockAccess worldIn, BlockPos pos) {
         return worldIn instanceof ChunkCache ? ((ChunkCache) worldIn)
               .getTileEntity(pos, Chunk.EnumCreateEntityType.CHECK) : worldIn.getTileEntity(pos);
+    }
+
+    /**
+     * Clamp a double to int without using Math.min due to double representation issues. Primary use: power systems that
+     * use int, where Mek uses doubles internally
+     *
+     * <code>
+     * double d = 1e300; // way bigger than longs, so the long should always be what's returned by Math.min
+     * System.out.println((long)Math.min(123456781234567812L, d)); // result is 123456781234567808 - 4 less than what
+     * you'd expect System.out.println((long)Math.min(123456789012345678L, d)); // result is 123456789012345680 - 2 more
+     * than what you'd expect
+     * </code>
+     *
+     * @param d double to clamp
+     * @return an int clamped to Integer.MAX_VALUE
+     * @see <a href="https://github.com/aidancbrady/Mekanism/pull/5203">Original PR</a>
+     */
+    public static int clampToInt(double d) {
+        if (d < Integer.MAX_VALUE) {
+            return (int) d;
+        } else {
+            return Integer.MAX_VALUE;
+        }
     }
 
     public enum ResourceType {


### PR DESCRIPTION
Port https://github.com/mekanism-mod/Mekanism/commit/486e5d451
Skips the part of "clamping" longs as they already get clamped with `Math.round()` as documented by the javadocs https://docs.oracle.com/javase/8/docs/api/java/lang/Math.html#round-double-