### PR TITLE
When creating fluids from gases set their alpha value to no transparency

### DIFF
--- a/src/main/java/mekanism/api/gas/Gas.java
+++ b/src/main/java/mekanism/api/gas/Gas.java
@@ -271,8 +271,8 @@ public class Gas {
                 int tint = getTint();
                 //Fluids use ARGB so make sure that we are not using a fully transparent tint.
                 // This fixes issues with some mods rendering our fluids as invisible
-                if ((tint >> 24 & 0xFF) == 0) {
-                    tint = 0xFF << 24 | tint;
+                if ((tint & 0xFF000000) == 0) {
+                    tint = 0xFF000000 | tint;
                 }
                 fluid = new Fluid(name, getIcon(), getIcon(), tint);
                 FluidRegistry.registerFluid(fluid);

--- a/src/main/java/mekanism/api/gas/Gas.java
+++ b/src/main/java/mekanism/api/gas/Gas.java
@@ -54,7 +54,7 @@ public class Gas {
      */
     public Gas(String s, int t) {
         this(s, "mekanism:blocks/liquid/liquid");
-        tint = t;
+        setTint(t);
     }
 
     /**
@@ -65,7 +65,7 @@ public class Gas {
         iconLocation = f.getStill();
         fluid = f;
         from_fluid = true;
-        tint = f.getColor() & 0xFFFFFF;
+        setTint(f.getColor() & 0xFFFFFF);
     }
 
     /**
@@ -268,7 +268,13 @@ public class Gas {
     public Gas registerFluid(String name) {
         if (fluid == null) {
             if (FluidRegistry.getFluid(name) == null) {
-                fluid = new Fluid(name, getIcon(), getIcon(), getTint());
+                int tint = getTint();
+                //Fluids use ARGB so make sure that we are not using a fully transparent tint.
+                // This fixes issues with some mods rendering our fluids as invisible
+                if ((tint >> 24 & 0xFF) == 0) {
+                    tint = 0xFF << 24 | tint;
+                }
+                fluid = new Fluid(name, getIcon(), getIcon(), tint);
                 FluidRegistry.registerFluid(fluid);
             } else {
                 fluid = FluidRegistry.getFluid(name);


### PR DESCRIPTION
Tints for gases are int he format `0xRRGGBB` whereas for fluids the format is `0xAARRGGBB`. This means that mods like Blood Magic, Tinker's Construct, Ceramics, etc that obey they alpha value of fluids for rendering would render our liquids as invisible.

At some point it may make sense for us to also obey the alpha value for when we render fluid's but I am currently unaware of any fluids that actually make use of this feature.