### PR TITLE
Ported metallurgy ore doubling and cyclic integration stuff

### DIFF
--- a/etc/core/mcmod.info
+++ b/etc/core/mcmod.info
@@ -26,7 +26,8 @@
       "galaticraft api",
       "metallurgy",
       "crafttweaker",
-      "cofhcore"
+      "cofhcore",
+      "cyclicmagic"
     ],
     "requiredMods": [
       "forge@[14.23.5.2768,)"

--- a/src/main/java/mekanism/common/Mekanism.java
+++ b/src/main/java/mekanism/common/Mekanism.java
@@ -952,6 +952,8 @@ public class Mekanism {
                     .setTranslationKey("obsidian"));
 
         Capabilities.registerCapabilities();
+
+        hooks.hookPreInit();
     }
 
     @EventHandler
@@ -994,22 +996,7 @@ public class Mekanism {
         //Load this module
         registerTileEntities();
 
-        //Integrate with Waila
-        FMLInterModComms.sendMessage(MekanismHooks.WAILA_MOD_ID, "register",
-              "mekanism.common.integration.WailaDataProvider.register");
-
-        //Register TOP handler
-        FMLInterModComms
-              .sendFunctionMessage("theoneprobe", "getTheOneProbe", "mekanism.common.integration.TOPProvider");
-
-        //Integrate with OpenComputers
-        if (Loader.isModLoaded(MekanismHooks.OPENCOMPUTERS_MOD_ID)) {
-            hooks.loadOCDrivers();
-        }
-
-        if (Loader.isModLoaded(MekanismHooks.APPLIED_ENERGISTICS_2_MOD_ID)) {
-            hooks.registerAE2P2P();
-        }
+        hooks.hookInit();
 
         //Packet registrations
         packetHandler.initialize();
@@ -1037,7 +1024,7 @@ public class Mekanism {
             Recipe.ENERGIZED_SMELTER.put(recipe);
         }
 
-        hooks.hook();
+        hooks.hookPostInit();
 
         MinecraftForge.EVENT_BUS.post(new BoxBlacklistEvent());
 

--- a/src/main/java/mekanism/common/integration/OreDictManager.java
+++ b/src/main/java/mekanism/common/integration/OreDictManager.java
@@ -26,6 +26,7 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.fml.common.Optional.Method;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -131,31 +132,7 @@ public final class OreDictManager {
             }
         }
 
-        for (String s : minorCompat) {
-            for (ItemStack ore : OreDictionary.getOres("ore" + s)) {
-                try {
-                    RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1),
-                          StackUtils.size(OreDictionary.getOres("dust" + s).get(0), 2));
-                } catch (Exception ignored) {
-                }
-            }
-
-            for (ItemStack ore : OreDictionary.getOres("ingot" + s)) {
-                try {
-                    RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1),
-                          StackUtils.size(OreDictionary.getOres("dust" + s).get(0), 1));
-                } catch (Exception ignored) {
-                }
-            }
-
-            for (ItemStack ore : OreDictionary.getOres("dust" + s)) {
-                try {
-                    RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), new ItemStack(Blocks.COBBLESTONE),
-                          StackUtils.size(OreDictionary.getOres("ore" + s).get(0), 1));
-                } catch (Exception ignored) {
-                }
-            }
-        }
+        minorCompat.forEach(OreDictManager::addStandardOredictMetal);
 
         for (ItemStack ore : OreDictionary.getOres("oreYellorite")) {
             try {
@@ -301,7 +278,7 @@ public final class OreDictManager {
     }
 
     @Method(modid = MekanismHooks.IC2_MOD_ID)
-    public static void addIC2BronzeRecipe() {
+    private static void addIC2BronzeRecipe() {
         try {
             Recipes.macerator.addRecipe(Recipes.inputFactory.forOreDict("ingotBronze"), null, false,
                   StackUtils.size(OreDictionary.getOres("dustBronze").get(0), 1));
@@ -314,7 +291,7 @@ public final class OreDictManager {
      * Handy method for retrieving all log items, finding their corresponding planks, and making recipes with them.
      * Credit to CofhCore.
      */
-    public static void addLogRecipes() {
+    private static void addLogRecipes() {
         Container tempContainer = new Container() {
             @Override
             public boolean canInteractWith(@Nonnull EntityPlayer player) {
@@ -348,6 +325,27 @@ public final class OreDictManager {
         if (!resultEntry.isEmpty()) {
             RecipeHandler.addPrecisionSawmillRecipe(log, StackUtils.size(resultEntry, 6),
                   new ItemStack(MekanismItems.Sawdust), general.sawdustChanceLog);
+        }
+    }
+
+    public static void addStandardOredictMetal(String suffix) {
+        NonNullList<ItemStack> dusts = OreDictionary.getOres("dust" + suffix);
+        NonNullList<ItemStack> ores = OreDictionary.getOres("ore" + suffix);
+        if (dusts.size() > 0) {
+            for (ItemStack ore : ores) {
+                RecipeHandler.addEnrichmentChamberRecipe(StackUtils.size(ore, 1), StackUtils.size(dusts.get(0), 2));
+            }
+
+            for (ItemStack ore : OreDictionary.getOres("ingot" + suffix)) {
+                RecipeHandler.addCrusherRecipe(StackUtils.size(ore, 1), StackUtils.size(dusts.get(0), 1));
+            }
+        }
+
+        if (ores.size() > 0) {
+            for (ItemStack ore : dusts) {
+                RecipeHandler.addCombinerRecipe(StackUtils.size(ore, 8), new ItemStack(Blocks.COBBLESTONE),
+                      StackUtils.size(ores.get(0), 1));
+            }
         }
     }
 }


### PR DESCRIPTION
More direct port of:
```
d2f0c24e5
847e78004
3456396d7
fd638902a
26abf5086
```
I still would like to eventually do a similar thing that I was attempting to in #5347 where we dynamically add recipes for registered oredictionary entries and am keeping my local branch work on it so I can work on it again in the future; but for now it is too much of a mess and probably will cause more issues than it will fix so is not worthwhile to do for the merge.