### PR TITLE
Factory recipe check

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityFactory.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFactory.java
@@ -449,9 +449,10 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
         int process = getOperation(slotID);
         //cached recipe may be invalid
         MachineRecipe cached = cachedRecipe[process];
+        ItemStack extra = inventory.get(4);
         if (cached == null) {
             cached = cachedRecipe[process] = recipeType
-                  .getAnyRecipe(fallbackInput, inventory.get(4), gasTank.getGasType(), infuseStored);
+                  .getAnyRecipe(fallbackInput, extra, gasTank.getGasType(), infuseStored);
         } else {
             ItemStack recipeInput = ItemStack.EMPTY;
             boolean secondaryMatch = true;
@@ -460,27 +461,28 @@ public class TileEntityFactory extends TileEntityMachine implements IComputerInt
             } else if (cached.recipeInput instanceof AdvancedMachineInput) {
                 AdvancedMachineInput advancedInput = (AdvancedMachineInput) cached.recipeInput;
                 recipeInput = advancedInput.itemStack;
+                secondaryMatch = gasTank.getGasType() == null || advancedInput.gasType == gasTank.getGasType();
             } else if (cached.recipeInput instanceof DoubleMachineInput) {
                 DoubleMachineInput doubleMachineInput = (DoubleMachineInput) cached.recipeInput;
                 recipeInput = doubleMachineInput.itemStack;
+                secondaryMatch = extra.isEmpty() || ItemStack.areItemsEqual(doubleMachineInput.extraStack, extra);
             }/*else if (cached.recipeInput instanceof PressurizedInput) {
                 PressurizedInput pressurizedInput = (PressurizedInput) cached.recipeInput;
                 recipeInput = pressurizedInput.getSolid();
-                secondaryMatch =
-                      pressurizedInput.getGas() == null || pressurizedInput.getGas().isGasEqual(gasTank.getGas());
+                secondaryMatch = gasTank.getGas() == null || gasTank.getGas().isGasEqual(pressurizedInput.getGas());
                 //TODO: Handle fluid for secondary matching if we ever have a PRC factory
                 pressurizedInput.getFluid();
             }*/ else if (cached.recipeInput instanceof InfusionInput) {
                 InfusionInput infusionInput = (InfusionInput) cached.recipeInput;
                 recipeInput = infusionInput.inputStack;
-                secondaryMatch = infusionInput.infuse.type == infuseStored.type;
+                secondaryMatch = infuseStored.amount == 0 || infuseStored.type == infusionInput.infuse.type;
             }
             //If there is no cached item input or it doesn't match our fallback
             // then it is an out of date cache so we compare against the new one
             // and update the cache while we are at it
             if (recipeInput.isEmpty() || !secondaryMatch || !ItemStack.areItemsEqual(recipeInput, fallbackInput)) {
                 cached = cachedRecipe[process] = recipeType
-                      .getAnyRecipe(fallbackInput, inventory.get(4), gasTank.getGasType(), infuseStored);
+                      .getAnyRecipe(fallbackInput, extra, gasTank.getGasType(), infuseStored);
             }
         }
         //If there is no recipe found


### PR DESCRIPTION
## Changes proposed in this pull request:
- Improve the recipe check for if an item can go in an input slot based on the current output to use the cached recipes. This updates the cached recipe if it seems to be out of date with the information we know.
- Also fixes the null pointer in #5392 and #5394 caused by attempting to get the recipe output of a null recipe. (For when items attempt to be inserted if they don't have a recipe that they match)
- Include some partially implemented code for if we ever have PRC factories to make it easier to have them support this recipe check.