### PR TITLE
Implement #5397 add a way to get CrT gas from string

### DIFF
--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/MekaTypeUtils.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/MekaTypeUtils.java
@@ -1,0 +1,17 @@
+package mekanism.common.integration.crafttweaker.handlers;
+
+import crafttweaker.annotations.ZenRegister;
+import mekanism.common.integration.crafttweaker.gas.GasBracketHandler;
+import mekanism.common.integration.crafttweaker.gas.IGasStack;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+
+@ZenClass("mods.mekanism.mekaTypeUtils")
+@ZenRegister
+public class MekaTypeUtils {
+
+    @ZenMethod
+    public static IGasStack getGas(String name) {
+        return GasBracketHandler.getGas(name);
+    }
+}

--- a/src/main/java/mekanism/common/integration/crafttweaker/handlers/MekanismHelper.java
+++ b/src/main/java/mekanism/common/integration/crafttweaker/handlers/MekanismHelper.java
@@ -6,9 +6,9 @@ import mekanism.common.integration.crafttweaker.gas.IGasStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-@ZenClass("mods.mekanism.mekaTypeUtils")
+@ZenClass("mods.mekanism.MekanismHelper")
 @ZenRegister
-public class MekaTypeUtils {
+public class MekanismHelper {
 
     @ZenMethod
     public static IGasStack getGas(String name) {


### PR DESCRIPTION
## Changes proposed in this pull request:
- Exposes `getGas` via the call `mods.mekanism.mekaTypeUtils.getGas(string);`
This change is in its own class so that eventually if/when we add more types (such as making infuse type a proper type instead of a string), then we can add ways to get them in this class.