### PR TITLE
Various fixes to data not loading properly

### DIFF
--- a/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
+++ b/src/main/java/mekanism/common/tile/TileEntityFluidTank.java
@@ -288,9 +288,10 @@ public class TileEntityFluidTank extends TileEntityContainerBlock implements IAc
         tier = FluidTankTier.values()[nbtTags.getInteger("tier")];
         clientActive = isActive = nbtTags.getBoolean("isActive");
         editMode = ContainerEditMode.values()[nbtTags.getInteger("editMode")];
+        //Needs to be outside the hasKey check because this is just based on the tier which is known information
+        fluidTank.setCapacity(tier.getStorage());
 
         if (nbtTags.hasKey("fluidTank")) {
-            fluidTank.setCapacity(tier.getStorage());
             fluidTank.readFromNBT(nbtTags.getCompoundTag("fluidTank"));
         }
     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -412,7 +412,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
             }
             //If the redstone mode changed properly update the connection to other transmitters/networks
             if (previouslyPowered != redstonePowered) {
-                markDirtyTransmitters();
+                notifyTileChange();
             }
 
             redstoneSet = true;
@@ -490,7 +490,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
         onWorldJoin();
         if (getPossibleTransmitterConnections() != currentTransmitterConnections) {
             //Mark the transmitters as invalidated if they do not match what we have stored/calculated
-            markDirtyTransmitters();
+            refreshConnections();
         }
         super.onLoad();
     }

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -10,13 +10,12 @@ import mekanism.api.Coord4D;
 import mekanism.api.EnumColor;
 import mekanism.api.IConfigurable;
 import mekanism.api.Range4D;
+import mekanism.api.TileNetworkList;
 import mekanism.api.transmitters.IBlockableConnection;
 import mekanism.api.transmitters.ITransmitter;
 import mekanism.api.transmitters.TransmissionType;
 import mekanism.common.Mekanism;
-import mekanism.common.tier.BaseTier;
 import mekanism.common.base.ITileNetwork;
-import mekanism.api.TileNetworkList;
 import mekanism.common.block.BlockTransmitter;
 import mekanism.common.block.property.PropertyConnection;
 import mekanism.common.block.states.BlockStateTransmitter.TransmitterType;
@@ -25,6 +24,7 @@ import mekanism.common.capabilities.Capabilities;
 import mekanism.common.integration.multipart.MultipartMekanism;
 import mekanism.common.integration.multipart.MultipartTileNetworkJoiner;
 import mekanism.common.network.PacketTileEntity.TileEntityMessage;
+import mekanism.common.tier.BaseTier;
 import mekanism.common.util.CapabilityUtils;
 import mekanism.common.util.MekanismUtils;
 import mekanism.common.util.MultipartUtils;
@@ -60,13 +60,13 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
     public byte currentTransmitterConnections = 0x00;
 
     public boolean sendDesc = false;
-    public boolean redstonePowered = false;
+    private boolean redstonePowered = false;
 
-    public boolean redstoneReactive = false;
+    private boolean redstoneReactive = false;
 
     public boolean forceUpdate = true;
 
-    public boolean redstoneSet = false;
+    private boolean redstoneSet = false;
 
     public ConnectionType[] connectionTypes = {ConnectionType.NORMAL, ConnectionType.NORMAL, ConnectionType.NORMAL,
           ConnectionType.NORMAL, ConnectionType.NORMAL, ConnectionType.NORMAL};
@@ -312,18 +312,20 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
 
     @Override
     public boolean canConnect(EnumFacing side) {
-        if (!redstoneSet) {
-            if (redstoneReactive) {
-                redstonePowered = MekanismUtils.isGettingPowered(getWorld(), new Coord4D(getPos(), getWorld()));
-            } else {
-                redstonePowered = false;
+        if (handlesRedstone()) {
+            if (!redstoneSet) {
+                if (redstoneReactive) {
+                    redstonePowered = MekanismUtils.isGettingPowered(getWorld(), new Coord4D(getPos(), getWorld()));
+                } else {
+                    redstonePowered = false;
+                }
+
+                redstoneSet = true;
             }
 
-            redstoneSet = true;
-        }
-
-        if (handlesRedstone() && redstoneReactive && redstonePowered) {
-            return false;
+            if (redstoneReactive && redstonePowered) {
+                return false;
+            }
         }
 
         if (Mekanism.hooks.MCMPLoaded) {
@@ -401,13 +403,20 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
     }
 
     public void refreshConnections() {
-        if (redstoneReactive) {
-            redstonePowered = MekanismUtils.isGettingPowered(getWorld(), new Coord4D(getPos(), getWorld()));
-        } else {
-            redstonePowered = false;
-        }
+        if (handlesRedstone()) {
+            boolean previouslyPowered = redstonePowered;
+            if (redstoneReactive) {
+                redstonePowered = MekanismUtils.isGettingPowered(getWorld(), new Coord4D(getPos(), getWorld()));
+            } else {
+                redstonePowered = false;
+            }
+            //If the redstone mode changed properly update the connection to other transmitters/networks
+            if (previouslyPowered != redstonePowered) {
+                markDirtyTransmitters();
+            }
 
-        redstoneSet = true;
+            redstoneSet = true;
+        }
 
         if (!getWorld().isRemote) {
             byte possibleTransmitters = getPossibleTransmitterConnections();
@@ -487,16 +496,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
     }
 
     public void onNeighborBlockChange(EnumFacing side) {
-        if (handlesRedstone()) {
-            boolean prevPowered = redstonePowered;
-            refreshConnections();
-
-            if (prevPowered != redstonePowered) {
-                markDirtyTransmitters();
-            }
-        } else {
-            refreshConnections();
-        }
+        refreshConnections();
     }
 
     public void onPartChanged(IMultipart part) {
@@ -632,8 +632,7 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
     @Override
     public boolean hasCapability(@Nonnull Capability<?> capability, EnumFacing facing) {
         return capability == Capabilities.CONFIGURABLE_CAPABILITY || capability == Capabilities.TILE_NETWORK_CAPABILITY
-              ||
-              capability == Capabilities.BLOCKABLE_CONNECTION_CAPABILITY || super.hasCapability(capability, facing);
+              || capability == Capabilities.BLOCKABLE_CONNECTION_CAPABILITY || super.hasCapability(capability, facing);
     }
 
     @Override

--- a/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
+++ b/src/main/java/mekanism/common/tile/transmitter/TileEntitySidedPipe.java
@@ -488,6 +488,10 @@ public abstract class TileEntitySidedPipe extends TileEntity implements ITileNet
     @Override
     public void onLoad() {
         onWorldJoin();
+        if (getPossibleTransmitterConnections() != currentTransmitterConnections) {
+            //Mark the transmitters as invalidated if they do not match what we have stored/calculated
+            markDirtyTransmitters();
+        }
         super.onLoad();
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request:
1. Fix capacity of fluid tanks sometimes being incorrect when loading an empty fluid tank.
2. Make transmitter networks update and correct and broken connection data on load. (Probably fixes any broken networks/breaking networks seen in #4676 )
3. Properly mark the transmitters as dirty if the redstone mode changed during refresh:

Before point 3 for example with the setup seen below, if you turned on redstone sensitivity for the middle pipe, flicked the lever, and then teleported a thousand blocks away. Teleporting back and disabling the redstone sensitivity (while the lever is still flicked) would get it into the broken state seen below. This also could happen where if you had a redstone signal going to the middle pipe (from a non broken state) and toggled the middle pipe to being redstone sensitive it would visually disconnect it from the other pipes except water would continue to flow through the setup.

![2019-04-15_17 07 55](https://user-images.githubusercontent.com/1203288/56170606-20c25400-5fb0-11e9-8d54-1b54a69719c4.png)
