### PR TITLE
improve texture of tank break particle

### DIFF
--- a/src/main/resources/assets/mekanism/models/block/fluid_tank.json
+++ b/src/main/resources/assets/mekanism/models/block/fluid_tank.json
@@ -1,4 +1,8 @@
 {
+	"textures": {
+		"all": "#frame",
+		"particle": "#frame"
+	},
 	"elements": [
 		{
 			"name": "RightGlass",


### PR DESCRIPTION
## Changes proposed in this pull request:
Makes break particles on fluid tank slightly darker so they don't get confused with missing texture, hopefully an improvement.